### PR TITLE
Fixed ENABLE_ADMISSION_CONTROLLER envvar type to string

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -44,7 +44,7 @@ spec:
             - name: RESOURCE_PREFIX
               value: openshift.com
             - name: ENABLE_ADMISSION_CONTROLLER
-              value: false
+              value: "false"
             - name: NAMESPACE
               valueFrom:
                 fieldRef:

--- a/manifests/4.2/sriov-network-operator.v0.0.1.clusterserviceversion.yaml
+++ b/manifests/4.2/sriov-network-operator.v0.0.1.clusterserviceversion.yaml
@@ -268,7 +268,7 @@ spec:
                     - name: RESOURCE_PREFIX
                       value: openshift.com
                     - name: ENABLE_ADMISSION_CONTROLLER
-                      value: true
+                      value: "true"
                     - name: NAMESPACE
                       valueFrom:
                         fieldRef:


### PR DESCRIPTION
YAML reserved the words "false" and "true" and assumes these are boolean
unless quoted, which makes applying the operator manifest to fail
because of unexpected type of the value attribute.