### PR TITLE
Fix mlnx plugin when linkType is IB

### DIFF
--- a/Dockerfile.sriov-network-config-daemon
+++ b/Dockerfile.sriov-network-config-daemon
@@ -5,7 +5,7 @@ RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
 RUN make plugins BIN_PATH=build/_output/pkg
 
 FROM centos:7
-RUN yum -y update; yum -y install hwdata mstflint net-tools; yum clean all
+RUN yum -y update; yum -y install hwdata mstflint; yum clean all
 LABEL io.k8s.display-name="sriov-network-config-daemon" \
       io.k8s.description="This is a daemon that manage and config sriov network devices in Kubernetes cluster"
 COPY --from=builder /go/src/github.com/openshift/sriov-network-operator/build/_output/cmd/sriov-network-config-daemon /usr/bin/

--- a/Dockerfile.sriov-network-config-daemon.rhel7
+++ b/Dockerfile.sriov-network-config-daemon.rhel7
@@ -5,7 +5,7 @@ RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
 RUN make plugins BIN_PATH=build/_output/pkg
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-RUN yum -y update; yum -y install hwdata mstflint net-tools; yum clean all
+RUN yum -y update; yum -y install hwdata mstflint; yum clean all
 LABEL io.k8s.display-name="OpenShift sriov-network-config-daemon" \
       io.k8s.description="This is a daemon that manage and config sriov network devices in Openshift cluster" \
       io.openshift.tags="openshift,networking,sr-iov" \


### PR DESCRIPTION
Fix bug when the link type is IB, because the mlnxNic `singlePort` and `firstPort` bool flags are not updated, the plugin always assume the NIC is 2 ports and the 2nd port should be updated
