### PR TITLE
Don't crash if grubby is not installed

### DIFF
--- a/bindata/scripts/enable-kargs.sh
+++ b/bindata/scripts/enable-kargs.sh
@@ -5,8 +5,7 @@ chroot /host/ which grubby
 
 # if grubby is not there, let's send a message
 if [ $? -ne 0 ]; then
-    echo "grubby not available"
-    exit
+    exit 127
 fi
 
 declare -a kargs=( "$@" )

--- a/bindata/scripts/enable-kargs.sh
+++ b/bindata/scripts/enable-kargs.sh
@@ -14,7 +14,7 @@ if grep --quiet CoreOS "$REDHAT_RELEASE_FILE"; then
         fi
     done
 else
-    chroot /host/ which grubby
+    chroot /host/ which grubby > /dev/null 2>&1
     # if grubby is not there, let's tell it
     if [ $? -ne 0 ]; then
         exit 127

--- a/bindata/scripts/enable-kargs.sh
+++ b/bindata/scripts/enable-kargs.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 set -x
+
+chroot /host/ which grubby
+
+# if grubby is not there, let's send a message
+if [ $? -ne 0 ]; then
+    echo "grubby not available"
+fi
+
 declare -a kargs=( "$@" )
 eval `chroot /host/ grubby --info=DEFAULT | grep args`
 ret=0

--- a/bindata/scripts/enable-kargs.sh
+++ b/bindata/scripts/enable-kargs.sh
@@ -6,6 +6,7 @@ chroot /host/ which grubby
 # if grubby is not there, let's send a message
 if [ $? -ne 0 ]; then
     echo "grubby not available"
+    exit
 fi
 
 declare -a kargs=( "$@" )

--- a/pkg/plugins/generic/generic_plugin.go
+++ b/pkg/plugins/generic/generic_plugin.go
@@ -20,10 +20,7 @@ type GenericPlugin struct {
 	LoadVfioDriver uint
 }
 
-const (
-	scriptsPath          = "bindata/scripts/enable-kargs.sh"
-	commandNotFoundError = 127
-)
+const scriptsPath = "bindata/scripts/enable-kargs.sh"
 
 const (
 	unloaded = iota

--- a/pkg/plugins/generic/generic_plugin.go
+++ b/pkg/plugins/generic/generic_plugin.go
@@ -173,6 +173,10 @@ func tryEnableIommuInKernelArgs() (bool, error) {
 		glog.Errorf("generic-plugin tryEnableIommuInKernelArgs(): fail to enable iommu %s: %v", args, err)
 		return false, err
 	}
+	if strings.TrimSpace(stdout.String()) == "grubby not available" {
+		glog.Infof("generic-plugin tryEnableIommuInKernelArgs(): grubby not available, assuming intel_iommu=on, iommu=pt")
+		return false, nil
+	}
 
 	i, err := strconv.Atoi(strings.TrimSpace(stdout.String()))
 	if err == nil {


### PR DESCRIPTION
The generic plugin uses grubby to check if `intel_iommu=on` and `iommu=pt` are set as kernel parameters.

This assumes that grubby is installed and that the current host is rhel based, which might not be the case in upstream. 
This pr checks for grubby existance and if it's not installed simply raises an error without having the node config daemon restart