### PR TITLE
Add a deploy-setup-k8s rule to deploy on upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,8 @@ test-e2e-local: operator-sdk
 test-e2e:
 	@hack/run-e2e-test.sh
 
+test-e2e-k8s: prepare-k8s test-e2e
+
 undeploy:
 	@hack/undeploy.sh sriov-network-operator
 

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,11 @@ gencode: operator-sdk
 deploy-setup:
 	@EXCLUSIONS=() hack/deploy-setup.sh sriov-network-operator
 
+prepare-k8s:
+    @CNI_BIN_PATH=/opt/cni/bin
+
+deploy-setup-k8s: prepare-k8s deploy-setup
+
 # test-unit:
 # 	@go test -v $(PKGS)
 test-e2e-local: operator-sdk

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ PKGS=$(shell go list ./... | grep -v -E '/vendor/|/test|/examples')
 # go source files, ignore vendor directory
 SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
-.PHONY: all operator-sdk build clean fmt gendeepcopy test-unit test-e2e run image
+.PHONY: all operator-sdk build clean fmt gendeepcopy test-unit test-e2e test-e2e-k8s run image
 
 all: build #check install
 
@@ -65,10 +65,9 @@ gencode: operator-sdk
 deploy-setup:
 	@EXCLUSIONS=() hack/deploy-setup.sh sriov-network-operator
 
-prepare-k8s:
-    @CNI_BIN_PATH=/opt/cni/bin
-
-deploy-setup-k8s: prepare-k8s deploy-setup
+    
+deploy-setup-k8s: export CNI_BIN_PATH=/opt/cni/bin
+deploy-setup-k8s: deploy-setup
 
 # test-unit:
 # 	@go test -v $(PKGS)
@@ -78,7 +77,8 @@ test-e2e-local: operator-sdk
 test-e2e:
 	@hack/run-e2e-test.sh
 
-test-e2e-k8s: prepare-k8s test-e2e
+test-e2e-k8s: export CNI_BIN_PATH=/opt/cni/bin
+test-e2e-k8s: test-e2e
 
 undeploy:
 	@hack/undeploy.sh sriov-network-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -55,3 +55,5 @@ spec:
                   fieldPath: metadata.name
             - name: RELEASE_VERSION
               value: 0.0.1-snapshot
+            - name: SRIOV_CNI_BIN_PATH
+              value: $CNI_BIN_PATH

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -22,8 +22,15 @@ make operator-sdk
 
 Deploy the operator. 
 
+If you are running an Openshift cluster:
+
 ```bash
 make deploy-setup
+```
+
+If you are running a Kubernetes cluster:
+```bash
+make deploy-setup-k8s
 ```
 
 By default, the operator will be deployed in namespace 'sriov-network-operator', you can check if the deployment is finished successfully.

--- a/hack/deploy-setup.sh
+++ b/hack/deploy-setup.sh
@@ -18,12 +18,13 @@ load_manifest() {
     if ! ${OPERATOR_EXEC} get ns sriov-network-operator > /dev/null 2>&1 && test -f namespace.yaml ; then
       ${OPERATOR_EXEC} apply -f namespace.yaml
     fi
-    files="crds/sriovnetwork_v1_sriovnetwork_crd.yaml crds/sriovnetwork_v1_sriovnetworknodepolicy_crd.yaml crds/sriovnetwork_v1_sriovnetworknodestate_crd.yaml service_account.yaml role.yaml role_binding.yaml clusterrole.yaml clusterrolebinding.yaml operator.yaml"
+    files="crds/sriovnetwork_v1_sriovnetwork_crd.yaml crds/sriovnetwork_v1_sriovnetworknodepolicy_crd.yaml crds/sriovnetwork_v1_sriovnetworknodestate_crd.yaml service_account.yaml role.yaml role_binding.yaml clusterrole.yaml clusterrolebinding.yaml"
     for m in ${files}; do
       if [ "$(echo ${EXCLUSIONS[@]} | grep -o ${m} | wc -w | xargs)" == "0" ] ; then
         ${OPERATOR_EXEC} apply -f ${m} ${namespace:-} --validate=false
       fi
     done
+    envsubst < operator.yaml | ${OPERATOR_EXEC} apply ${namespace:-} --validate=false -f -
   popd
 }
 

--- a/hack/deploy-setup.sh
+++ b/hack/deploy-setup.sh
@@ -24,7 +24,10 @@ load_manifest() {
         ${OPERATOR_EXEC} apply -f ${m} ${namespace:-} --validate=false
       fi
     done
-    envsubst < operator.yaml | ${OPERATOR_EXEC} apply ${namespace:-} --validate=false -f -
+    # handling operator.yaml as special case since it needs env variable substitutions
+    if [ "$(echo ${EXCLUSIONS[@]} | grep -o operator.yaml | wc -w | xargs)" == "0" ] ; then
+      envsubst < operator.yaml | ${OPERATOR_EXEC} apply ${namespace:-} --validate=false -f -
+    fi
   popd
 }
 

--- a/hack/run-e2e-test.sh
+++ b/hack/run-e2e-test.sh
@@ -9,5 +9,5 @@ SRIOV_NETWORK_CONFIG_DAEMON_IMAGE=${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE:-quay.io/o
 SRIOV_NETWORK_OPERATOR_IMAGE=${SRIOV_NETWORK_OPERATOR_IMAGE:-quay.io/openshift/origin-sriov-network-operator}
 
 echo ${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE}
-sed "s|quay.io/openshift/origin-sriov-network-config-daemon|${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE}|g;s|quay.io/openshift/origin-sriov-network-operator|${SRIOV_NETWORK_OPERATOR_IMAGE}|g;s|IfNotPresent|Always|g" deploy/operator.yaml > deploy/operator-init.yaml
+envsubst < operator.yaml deploy/operator.yaml | sed "s|quay.io/openshift/origin-sriov-network-config-daemon|${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE}|g;s|quay.io/openshift/origin-sriov-network-operator|${SRIOV_NETWORK_OPERATOR_IMAGE}|g;s|IfNotPresent|Always|g"  > deploy/operator-init.yaml
 go test ./test/e2e/... -root=$(pwd) -kubeconfig=$KUBECONFIG -globalMan deploy/crds/sriovnetwork_v1_sriovnetwork_crd.yaml -namespacedMan deploy/operator-init.yaml -v -singleNamespace true

--- a/hack/run-e2e-test.sh
+++ b/hack/run-e2e-test.sh
@@ -9,5 +9,5 @@ SRIOV_NETWORK_CONFIG_DAEMON_IMAGE=${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE:-quay.io/o
 SRIOV_NETWORK_OPERATOR_IMAGE=${SRIOV_NETWORK_OPERATOR_IMAGE:-quay.io/openshift/origin-sriov-network-operator}
 
 echo ${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE}
-envsubst < operator.yaml deploy/operator.yaml | sed "s|quay.io/openshift/origin-sriov-network-config-daemon|${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE}|g;s|quay.io/openshift/origin-sriov-network-operator|${SRIOV_NETWORK_OPERATOR_IMAGE}|g;s|IfNotPresent|Always|g"  > deploy/operator-init.yaml
+envsubst < deploy/operator.yaml | sed "s|quay.io/openshift/origin-sriov-network-config-daemon|${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE}|g;s|quay.io/openshift/origin-sriov-network-operator|${SRIOV_NETWORK_OPERATOR_IMAGE}|g;s|IfNotPresent|Always|g"  > deploy/operator-init.yaml
 go test ./test/e2e/... -root=$(pwd) -kubeconfig=$KUBECONFIG -globalMan deploy/crds/sriovnetwork_v1_sriovnetwork_crd.yaml -namespacedMan deploy/operator-init.yaml -v -singleNamespace true


### PR DESCRIPTION
This is a follow up to https://github.com/openshift/sriov-network-operator/pull/47 

With that, if I want to deploy the operator upstream I need to provide my own (modified) operator deployment manifest or have some script machinery to hack the one from the operator repository, which results in a non pleasant user experience.

With this pr I add a `deploy-setup-k8s` rule that sets the env variable to the value expected upstream.
Normally the default value will be used and the current path will be preserved.


