### PR TITLE
Add a way to disable node reboot

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -50,6 +50,7 @@ rules:
   - ""
   resources:
   - pods
+  - configmaps
   verbs:
   - '*'
 - apiGroups:

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -343,15 +343,12 @@ func (dn *Daemon) restartDevicePluginPod() error {
 			return err
 		}
 
-		var lastErr error
-
 		if err := wait.PollImmediateUntil(3*time.Second, func() (bool, error) {
 			_, err := dn.kubeClient.CoreV1().Pods(namespace).Get(pods.Items[0].GetName(), metav1.GetOptions{})
 			if err != nil {
 				if errors.IsNotFound(err) {
 					return true, nil
 				}
-				lastErr = err
 				glog.Infof("restartDevicePluginPod(): unexpected error: %v, retrying", err)
 				return false, err
 			}


### PR DESCRIPTION
We are planning to use the operator to set up sriov in kubevirt CI environment.
Since the whole setup is a kind cluster spun up as a prow job, a reboot of what the operator thinks is a node would be a reboot of the whole CI node.

With this PR, if a configmap is present, the node configuration daemon will log an error and exit instead of rebooting the node, so that the user of CI can check what is missing and schedule an intervention.