### PR TITLE
Add info about using kubectl instead of oc in case of k8s

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -30,6 +30,7 @@ make deploy-setup
 
 If you are running a Kubernetes cluster:
 ```bash
+export OPERATOR_EXEC=kubectl
 make deploy-setup-k8s
 ```
 


### PR DESCRIPTION
`make deploy-setup` defaults the command to use to `oc`. 
This pr documents how to override the command to use `kubectl` in case of upstream.