### PR TITLE
add manifests/art.yaml

### DIFF
--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -1,0 +1,12 @@
+updates:
+  - file: "{MAJOR}.{MINOR}/sriov-network-operator.v0.0.1.clusterserviceversion.yaml" # relative to this file
+    update_list:
+    # replace metadata.name value
+    - search: "sriov-network-operator.v0.0.1"
+      replace: "sriov-network-operator.{FULL_VER}"
+    - search: "version: 0.0.1"
+      replace: "version: {FULL_VER}"
+  - file: "sriov-network-operator.package.yaml"
+    update_list:
+    - search: "currentCSV: sriov-network-operator.v0.0.1"
+      replace: "currentCSV: sriov-network-operator.{FULL_VER}"


### PR DESCRIPTION
This gives us different CSVs for different releases (e.g. 4.2 and 4.3)
when we're building OCP downstream.

This should be cherry-picked back to 4.2 but the problem we have (duplicate CSVs) will go away for now even if just 4.3 gets changed.