### PR TITLE
use consistent sriov label

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,13 @@ spec:
     - 0000:86:00.0
     vendor: "8086"
   nodeSelector:
-    feature.node.kubernetes.io/sriov-capable: "true"
+    feature.node.kubernetes.io/network-sriov.capable: "true"
   numVfs: 4
   priority: 90
   resourceName: intelnics
 ```
 
-In this example, user selected the nice from vendor '8086' which is intel, device module is '1583' which is XL710 for 40GbE, on nodes labeled with 'sriov-capable' equals 'true'. Then for those PFs, create 4 VFs each, set mtu to 1500 and the load the vfio-pci driver to those virtual functions.
+In this example, user selected the nice from vendor '8086' which is intel, device module is '1583' which is XL710 for 40GbE, on nodes labeled with 'network-sriov.capable' equals 'true'. Then for those PFs, create 4 VFs each, set mtu to 1500 and the load the vfio-pci driver to those virtual functions.
 
 ## Components and design
 

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -95,7 +95,7 @@ metadata:
   namespace: sriov-network-operator
 spec:
   nodeSelector:
-    feature.node.kubernetes.io/sriov-capable: "true"
+    feature.node.kubernetes.io/network-sriov.capable: "true"
   resourceName: intelnics
   priority: 99
   mtu: 9000

--- a/manifests/4.3/sriov-network-operator.v0.0.1.clusterserviceversion.yaml
+++ b/manifests/4.3/sriov-network-operator.v0.0.1.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
           "spec": {
             "resourceName": "intelnics",
             "nodeSelector": {
-              "feature.node.kubernetes.io/sriov-capable": "true"
+              "feature.node.kubernetes.io/network-sriov.capable": "true"
             },
             "priority": 99,
             "mtu": 9000,


### PR DESCRIPTION
change sriov-capable label to network-sriov.capable
which is consistent with nfd sriov label.