### PR TITLE
remove quotes of vlanQoS in generated net-attach-def

### DIFF
--- a/bindata/manifests/cni-config/sriov-cni-config.yaml
+++ b/bindata/manifests/cni-config/sriov-cni-config.yaml
@@ -24,7 +24,7 @@ spec:
   "link_state":"{{.SriovCniState}}",
 {{- end -}}
 {{- if .VlanQoSConfigured -}}
-  "vlanQoS":"{{.SriovCniVlanQoS}}",
+  "vlanQoS":{{.SriovCniVlanQoS}},
 {{- end -}}
   {{.SriovCniIpam}}
 }'


### PR DESCRIPTION
VlanQoS is an int value in SR-IOV CNI, the generated
config should be integer instead of string.