### PR TITLE
Do not require mstflint on s390x

### DIFF
--- a/Dockerfile.sriov-network-config-daemon
+++ b/Dockerfile.sriov-network-config-daemon
@@ -5,7 +5,7 @@ RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
 RUN make plugins BIN_PATH=build/_output/pkg
 
 FROM centos:7
-RUN yum -y update && yum --setopt=skip_missing_names_on_install=False -y install hwdata mstflint && yum clean all
+RUN yum -y update && ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n mstflint ; fi) && yum -y install hwdata $ARCH_DEP_PKGS && yum clean all
 LABEL io.k8s.display-name="sriov-network-config-daemon" \
       io.k8s.description="This is a daemon that manage and config sriov network devices in Kubernetes cluster"
 COPY --from=builder /go/src/github.com/openshift/sriov-network-operator/build/_output/cmd/sriov-network-config-daemon /usr/bin/

--- a/Dockerfile.sriov-network-config-daemon.rhel7
+++ b/Dockerfile.sriov-network-config-daemon.rhel7
@@ -5,7 +5,7 @@ RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
 RUN make plugins BIN_PATH=build/_output/pkg
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-RUN yum -y update && yum --setopt=skip_missing_names_on_install=False -y install hwdata mstflint && yum clean all
+RUN yum -y update && ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n mstflint ; fi) && yum -y install hwdata $ARCH_DEP_PKGS && yum clean all
 LABEL io.k8s.display-name="OpenShift sriov-network-config-daemon" \
       io.k8s.description="This is a daemon that manage and config sriov network devices in Openshift cluster" \
       io.openshift.tags="openshift,networking,sr-iov" \


### PR DESCRIPTION
mstflint is only required for the mellanox plugin, which is a no-op on IBM Z.