### PR TITLE
Bug 1814919: Prevent user from setting numVfs to '0'

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -176,7 +176,7 @@ func createDefaultPolicy(cfg *rest.Config) error {
 	}
 	policy := &sriovnetworkv1.SriovNetworkNodePolicy{
 		Spec: sriovnetworkv1.SriovNetworkNodePolicySpec{
-			NumVfs:       0,
+			NumVfs:       1,
 			NodeSelector: make(map[string]string),
 			NicSelector:  sriovnetworkv1.SriovNetworkNicSelector{},
 		},

--- a/deploy/crds/sriovnetwork.openshift.io_sriovnetworknodepolicies_crd.yaml
+++ b/deploy/crds/sriovnetwork.openshift.io_sriovnetworknodepolicies_crd.yaml
@@ -86,7 +86,7 @@ spec:
               type: object
             numVfs:
               description: Number of VFs for each PF
-              minimum: 0
+              minimum: 1
               type: integer
             priority:
               description: Priority of the policy, higher priority policies can override

--- a/manifests/4.5/sriov-network-operator-sriovnetwork.crd.yaml
+++ b/manifests/4.5/sriov-network-operator-sriovnetwork.crd.yaml
@@ -20,12 +20,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/manifests/4.5/sriov-network-operator-sriovnetworknodepolicy.crd.yaml
+++ b/manifests/4.5/sriov-network-operator-sriovnetworknodepolicy.crd.yaml
@@ -21,12 +21,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -86,7 +86,7 @@ spec:
               type: object
             numVfs:
               description: Number of VFs for each PF
-              minimum: 0
+              minimum: 1
               type: integer
             priority:
               description: Priority of the policy, higher priority policies can override

--- a/manifests/4.5/sriov-network-operator-sriovnetworknodestate.crd.yaml
+++ b/manifests/4.5/sriov-network-operator-sriovnetworknodestate.crd.yaml
@@ -21,12 +21,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -69,18 +69,12 @@ spec:
         status:
           description: SriovNetworkNodeStateStatus defines the observed state of SriovNetworkNodeState
           properties:
-            lastSyncError:
-              type: string
-            syncStatus:
-              type: string
             interfaces:
               items:
                 properties:
                   Vfs:
                     items:
                       properties:
-                        vfID:
-                          type: integer
                         Vlan:
                           type: integer
                         assigned:
@@ -92,7 +86,6 @@ spec:
                         mac:
                           type: string
                         mtu:
-                          format: int64
                           type: integer
                         name:
                           type: string
@@ -100,6 +93,11 @@ spec:
                           type: string
                         vendor:
                           type: string
+                        vfID:
+                          type: integer
+                      required:
+                      - pciAddress
+                      - vfID
                       type: object
                     type: array
                   deviceID:
@@ -108,18 +106,17 @@ spec:
                     type: string
                   linkSpeed:
                     type: string
+                  mac:
+                    type: string
                   mtu:
-                    format: int64
                     type: integer
                   name:
                     type: string
                   numVfs:
-                    format: int64
                     type: integer
                   pciAddress:
                     type: string
                   totalvfs:
-                    format: int64
                     type: integer
                   vendor:
                     type: string
@@ -127,6 +124,10 @@ spec:
                 - pciAddress
                 type: object
               type: array
+            lastSyncError:
+              type: string
+            syncStatus:
+              type: string
           type: object
       type: object
   version: v1

--- a/manifests/4.5/sriov-network-operator-sriovoperatorconfig.crd.yaml
+++ b/manifests/4.5/sriov-network-operator-sriovoperatorconfig.crd.yaml
@@ -21,12 +21,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/pkg/apis/sriovnetwork/v1/sriovnetworknodepolicy_types.go
+++ b/pkg/apis/sriovnetwork/v1/sriovnetworknodepolicy_types.go
@@ -23,7 +23,7 @@ type SriovNetworkNodePolicySpec struct {
 	// +kubebuilder:validation:Maximum=9000
 	// MTU of VF
 	Mtu int `json:"mtu,omitempty"`
-	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=1
 	// Number of VFs for each PF
 	NumVfs int `json:"numVfs"`
 	// NicSelector selects the NICs to be configured


### PR DESCRIPTION
Also, sync the 4.5 CRD in the manifest directory, as it was not done in the operator-sdk upgrade PR.