### PR TITLE
Use DeepDerivative to compare the the kube object content

### DIFF
--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -90,7 +90,7 @@ func ApplyObject(ctx context.Context, client k8sclient.Client, obj *uns.Unstruct
 	if err := MergeObjectForUpdate(existing, obj); err != nil {
 		return errors.Wrapf(err, "could not merge object %s with existing", objDesc)
 	}
-	if !equality.Semantic.DeepEqual(existing, obj) {
+	if !equality.Semantic.DeepDerivative(obj, existing) {
 		if err := client.Update(ctx, obj); err != nil {
 			return errors.Wrapf(err, "could not update object %s", objDesc)
 		} else {

--- a/pkg/apply/merge.go
+++ b/pkg/apply/merge.go
@@ -10,11 +10,6 @@ import (
 // This is to be able to do a a meaningful comparison in apply,
 // since objects created on runtime do not have these fields populated.
 func MergeMetadataForUpdate(current, updated *uns.Unstructured) error {
-	updated.SetCreationTimestamp(current.GetCreationTimestamp())
-	updated.SetSelfLink(current.GetSelfLink())
-	updated.SetGeneration(current.GetGeneration())
-	updated.SetUID(current.GetUID())
-	updated.SetResourceVersion(current.GetResourceVersion())
 
 	mergeAnnotations(current, updated)
 	mergeLabels(current, updated)
@@ -133,8 +128,9 @@ func mergeAnnotations(current, updated *uns.Unstructured) {
 	for k, v := range updatedAnnotations {
 		curAnnotations[k] = v
 	}
-
-	updated.SetAnnotations(curAnnotations)
+	if len(curAnnotations) > 1 {
+		updated.SetAnnotations(curAnnotations)
+	}
 }
 
 // mergeLabels copies over any labels from current to updated,
@@ -150,8 +146,9 @@ func mergeLabels(current, updated *uns.Unstructured) {
 	for k, v := range updatedLabels {
 		curLabels[k] = v
 	}
-
-	updated.SetLabels(curLabels)
+	if len(curLabels) > 1 {
+		updated.SetLabels(curLabels)
+	}
 }
 
 // IsObjectSupported rejects objects with configurations we don't support.


### PR DESCRIPTION
`DeepEqual` compares all the fields in the objects, however, we want to only focus on the fields set by the controller. This PR will also fix the problem that the controller keeps reconciling, due to the `DeepEqual` always returns false.