### PR TITLE
Add the [sriov] tag to conformance tests, to make it easier to filter

### DIFF
--- a/test/conformance/tests/sriov_operator.go
+++ b/test/conformance/tests/sriov_operator.go
@@ -28,7 +28,7 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("operator", func() {
+var _ = Describe("[sriov] operator", func() {
 	var sriovInfos *cluster.EnabledNodes
 	execute.BeforeAll(func() {
 		err := namespaces.Create(namespaces.Test, clients)

--- a/test/conformance/tests/vfs_assignement.go
+++ b/test/conformance/tests/vfs_assignement.go
@@ -22,7 +22,7 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("pod", func() {
+var _ = Describe("[sriov] pod", func() {
 	var sriovInfos *cluster.EnabledNodes
 	execute.BeforeAll(func() {
 		err := namespaces.Create(namespaces.Test, clients)


### PR DESCRIPTION
This will allow us to filter sriov tests when using the tests as a dependency