### PR TITLE
Bug 1841063: [Release-4.4] Introduce a custom Dailer to close TCP connections when heartbeat fails

### DIFF
--- a/cmd/sriov-network-config-daemon/start.go
+++ b/cmd/sriov-network-config-daemon/start.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"net"
 	"os"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/connrotation"
 )
 
 var (
@@ -79,9 +82,12 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		// creates the in-cluster config
 		config, err = rest.InClusterConfig()
 	}
-	// set client timeout to prevent REST call wait forever when not able to reach the API server.
-	config.Timeout = 15 * time.Second
 
+	if err != nil {
+		panic(err.Error())
+	}
+
+	closeAllConns, err := updateDialer(config)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -91,8 +97,10 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	snclient := snclientset.NewForConfigOrDie(config)
 	kubeclient := kubernetes.NewForConfigOrDie(config)
 
+	config.Timeout = 5 * time.Second
+	writerclient := snclientset.NewForConfigOrDie(config)
 	glog.V(0).Info("starting node writer")
-	nodeWriter := daemon.NewNodeStateStatusWriter(snclient, startOpts.nodeName)
+	nodeWriter := daemon.NewNodeStateStatusWriter(writerclient, startOpts.nodeName, closeAllConns)
 	// block the deamon process until nodeWriter finish first its run
 	nodeWriter.Run(stopCh, refreshCh, syncCh, true)
 	go nodeWriter.Run(stopCh, refreshCh, syncCh, false)
@@ -111,4 +119,14 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	}
 	<-syncCh
 	glog.V(0).Info("Shutting down SriovNetworkConfigDaemon")
+}
+
+// updateDialer instruments a restconfig with a dial. the returned function allows forcefully closing all active connections.
+func updateDialer(clientConfig *rest.Config) (func(), error) {
+	if clientConfig.Transport != nil || clientConfig.Dial != nil {
+		return nil, fmt.Errorf("there is already a transport or dialer configured")
+	}
+	d := connrotation.NewDialer((&net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}).DialContext)
+	clientConfig.Dial = d.DialContext
+	return d.CloseAll, nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -253,7 +253,7 @@ func setSriovNumVfs(pciAddr string, numVfs int) error {
 func setNetdevMTU(pciAddr string, mtu int) error {
 	glog.V(2).Infof("setNetdevMTU(): set MTU for device %s", pciAddr)
 	if mtu <= 0 {
-		glog.V(2).Infof("setNetdevMTU(): not set MTU to %s", mtu)
+		glog.V(2).Infof("setNetdevMTU(): not set MTU to %d", mtu)
 		return nil
 	}
 	b := backoff.NewConstantBackOff(1 * time.Second)


### PR DESCRIPTION
Force close connections on heartbeat failure, when heartbeat failed, we invoke closeAllConns and reestablish new connections. We use the writer's periodic Get() call as hearbeat singal, to detect whether the HTTP connection to the apiserver is still healthy.

This is a manual cherry pick of https://github.com/openshift/sriov-network-operator/pull/200
