### PR TITLE
run rebootNode in frontstage

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -359,7 +359,7 @@ func (dn *Daemon) nodeStateChangeHandler(old, new interface{}) {
 
 	if reqReboot {
 		glog.Info("nodeStateChangeHandler(): reboot node")
-		go rebootNode()
+		rebootNode()
 		return
 	}
 


### PR DESCRIPTION
This fix a possible race condition that:
node be uncordoned while node is still in the process
of rebooting in rebootNode go routine.