### PR TITLE
Bug 1839754: Remove required feilds from SriovNetworkNodeState CRD

### DIFF
--- a/deploy/crds/sriovnetwork.openshift.io_sriovnetworknodestates_crd.yaml
+++ b/deploy/crds/sriovnetwork.openshift.io_sriovnetworknodestates_crd.yaml
@@ -57,15 +57,10 @@ spec:
                           type: string
                         vfRange:
                           type: string
-                      required:
-                      - policyName
-                      - resourceName
                       type: object
                     type: array
                 required:
-                - name
                 - pciAddress
-                - vfGroups
                 type: object
               type: array
           type: object

--- a/manifests/4.6/sriov-network-operator-sriovnetworknodestate.crd.yaml
+++ b/manifests/4.6/sriov-network-operator-sriovnetworknodestate.crd.yaml
@@ -57,15 +57,10 @@ spec:
                           type: string
                         vfRange:
                           type: string
-                      required:
-                      - policyName
-                      - resourceName
                       type: object
                     type: array
                 required:
-                - name
                 - pciAddress
-                - vfGroups
                 type: object
               type: array
           type: object

--- a/pkg/apis/sriovnetwork/v1/sriovnetworknodestate_types.go
+++ b/pkg/apis/sriovnetwork/v1/sriovnetworknodestate_types.go
@@ -18,15 +18,15 @@ type Interface struct {
 	PciAddress string    `json:"pciAddress"`
 	NumVfs     int       `json:"numVfs,omitempty"`
 	Mtu        int       `json:"mtu,omitempty"`
-	Name       string    `json:"name, omitempty"`
-	VfGroups   []VfGroup `json:"vfGroups, omitempty"`
+	Name       string    `json:"name,omitempty"`
+	VfGroups   []VfGroup `json:"vfGroups,omitempty"`
 }
 
 type VfGroup struct {
-	ResourceName string `json:"resourceName"`
+	ResourceName string `json:"resourceName,omitempty"`
 	DeviceType   string `json:"deviceType,omitempty"`
 	VfRange      string `json:"vfRange,omitempty"`
-	PolicyName   string `json:"policyName"`
+	PolicyName   string `json:"policyName,omitempty"`
 }
 
 type Interfaces []Interface


### PR DESCRIPTION
OLM doesn't allow CRD to introduce new required fields during an upgrade.