### PR TITLE
Export a clean.All function that removes all the leftovers from the conformance suite

### DIFF
--- a/test/conformance/test_suite_test.go
+++ b/test/conformance/test_suite_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/openshift/sriov-network-operator/test/util/clean"
+
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
@@ -53,3 +55,8 @@ func TestTest(t *testing.T) {
 
 	RunSpecsWithDefaultAndCustomReporters(t, "SRIOV Operator conformance tests", rr)
 }
+
+var _ = AfterSuite(func() {
+	err := clean.All()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/test/conformance/test_suite_test.go
+++ b/test/conformance/test_suite_test.go
@@ -10,9 +10,7 @@ import (
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 
-	sriovv1 "github.com/openshift/sriov-network-operator/pkg/apis/sriovnetwork/v1"
 	testclient "github.com/openshift/sriov-network-operator/test/util/client"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	_ "github.com/openshift/sriov-network-operator/test/conformance/tests"
 	"github.com/openshift/sriov-network-operator/test/util/k8sreporter"
@@ -38,9 +36,7 @@ func TestTest(t *testing.T) {
 
 	reporterFile := os.Getenv("REPORTER_OUTPUT")
 
-	clients := testclient.New("", func(scheme *runtime.Scheme) {
-		sriovv1.AddToScheme(scheme)
-	})
+	clients := testclient.New("")
 
 	if reporterFile != "" {
 		f, err := os.OpenFile(reporterFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)

--- a/test/conformance/tests/init.go
+++ b/test/conformance/tests/init.go
@@ -3,9 +3,7 @@ package tests
 import (
 	"os"
 
-	sriovv1 "github.com/openshift/sriov-network-operator/pkg/apis/sriovnetwork/v1"
 	testclient "github.com/openshift/sriov-network-operator/test/util/client"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var (
@@ -19,8 +17,6 @@ func init() {
 		operatorNamespace = "openshift-sriov-network-operator"
 	}
 
-	clients = testclient.New("", func(scheme *runtime.Scheme) {
-		sriovv1.AddToScheme(scheme)
-	})
+	clients = testclient.New("")
 
 }

--- a/test/e2e/e2e_tests_suite_test.go
+++ b/test/e2e/e2e_tests_suite_test.go
@@ -16,7 +16,6 @@ import (
 	// corev1 "k8s.io/api/core/v1"
 	// "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	// "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	// dynclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -64,9 +63,7 @@ var _ = BeforeSuite(func() {
 	deploy := &appsv1.Deployment{}
 	err := WaitForNamespacedObject(deploy, f.Client, namespace, "sriov-network-operator", RetryInterval, Timeout)
 	Expect(err).NotTo(HaveOccurred())
-	clients := testclient.New("", func(scheme *runtime.Scheme) {
-		sriovnetworkv1.AddToScheme(scheme)
-	})
+	clients := testclient.New("")
 	var sriovInfos *cluster.EnabledNodes
 	err = wait.PollImmediate(RetryInterval, Timeout*15, func() (done bool, err error) {
 		sriovInfos, err = cluster.DiscoverSriov(clients, namespace)

--- a/test/util/clean/clean.go
+++ b/test/util/clean/clean.go
@@ -1,0 +1,34 @@
+package clean
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/openshift/sriov-network-operator/test/util/client"
+	"github.com/openshift/sriov-network-operator/test/util/namespaces"
+)
+
+// All cleans all the dangling resources created by conformance tests.
+// This includes pods, networks, policies and namespaces.
+func All() error {
+	operatorNamespace, found := os.LookupEnv("OPERATOR_NAMESPACE")
+	if !found {
+		operatorNamespace = "openshift-sriov-network-operator"
+	}
+
+	clients := client.New("")
+	if !namespaces.Exists(namespaces.Test, clients) {
+		return nil
+	}
+	err := namespaces.Clean(operatorNamespace, namespaces.Test, clients)
+	if err != nil {
+		return fmt.Errorf("Failed to clean sriov resources %v", err)
+	}
+
+	err = namespaces.DeleteAndWait(clients, namespaces.Test, 5*time.Minute)
+	if err != nil {
+		return fmt.Errorf("Failed to delete sriov tests namespace %v", err)
+	}
+	return nil
+}

--- a/test/util/client/clients.go
+++ b/test/util/client/clients.go
@@ -8,12 +8,14 @@ import (
 	"github.com/golang/glog"
 	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	clientmachineconfigv1 "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1"
+	sriovv1 "github.com/openshift/sriov-network-operator/pkg/apis/sriovnetwork/v1"
 	clientsriovv1 "github.com/openshift/sriov-network-operator/pkg/client/clientset/versioned/typed/sriovnetwork/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	discovery "k8s.io/client-go/discovery"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,7 +36,7 @@ type ClientSet struct {
 }
 
 // New returns a *ClientBuilder with the given kubeconfig.
-func New(kubeconfig string, addToScheme func(*runtime.Scheme)) *ClientSet {
+func New(kubeconfig string) *ClientSet {
 	var config *rest.Config
 	var err error
 
@@ -65,7 +67,8 @@ func New(kubeconfig string, addToScheme func(*runtime.Scheme)) *ClientSet {
 	crScheme := runtime.NewScheme()
 	clientgoscheme.AddToScheme(crScheme)
 	netattdefv1.SchemeBuilder.AddToScheme(crScheme)
-	addToScheme(crScheme)
+	sriovv1.AddToScheme(crScheme)
+
 	clientSet.Client, err = runtimeclient.New(config, client.Options{
 		Scheme: crScheme,
 	})

--- a/test/util/namespaces/namespaces.go
+++ b/test/util/namespaces/namespaces.go
@@ -55,14 +55,15 @@ func DeleteAndWait(cs *testclient.ClientSet, namespace string, timeout time.Dura
 	return WaitForDeletion(cs, namespace, timeout)
 }
 
-func namespaceExists(namespace string, cs *testclient.ClientSet) bool {
+// Exists tells whether the given namespace exists
+func Exists(namespace string, cs *testclient.ClientSet) bool {
 	_, err := cs.Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 	return err == nil || !k8serrors.IsNotFound(err)
 }
 
 // CleanPods deletes all pods in namespace
 func CleanPods(namespace string, cs *testclient.ClientSet) error {
-	if !namespaceExists(namespace, cs) {
+	if !Exists(namespace, cs) {
 		return nil
 	}
 	err := cs.Pods(namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{


### PR DESCRIPTION
This is useful when using the suite as a dependency, to restore the cluster to the original state.