### PR TITLE
Detect partition overlap regardless of rootDevices

### DIFF
--- a/pkg/webhook/validate.go
+++ b/pkg/webhook/validate.go
@@ -168,19 +168,17 @@ func validatePolicyForNodeState(policy *sriovnetworkv1.SriovNetworkNodePolicy, s
 	}
 
 	for _, iface := range state.Spec.Interfaces {
-		if sriovnetworkv1.StringInArray(iface.PciAddress, policy.Spec.NicSelector.RootDevices) {
-			if len(policy.Spec.NicSelector.PfNames) > 0 {
-				for _, pf := range policy.Spec.NicSelector.PfNames {
-					name, rngSt, rngEnd, err := sriovnetworkv1.ParsePFName(pf)
-					if err != nil {
-						return false, fmt.Errorf("invalid PF name: %s", pf)
-					}
-					if name == iface.Name {
-						for _, group := range iface.VfGroups {
-							if sriovnetworkv1.IndexInRange(rngSt, group.VfRange) || sriovnetworkv1.IndexInRange(rngEnd, group.VfRange) {
-								if group.PolicyName != policy.GetName() {
-									return false, fmt.Errorf("Vf index range in %s is overlapped with existing policies", pf)
-								}
+		if len(policy.Spec.NicSelector.PfNames) > 0 {
+			for _, pf := range policy.Spec.NicSelector.PfNames {
+				name, rngSt, rngEnd, err := sriovnetworkv1.ParsePFName(pf)
+				if err != nil {
+					return false, fmt.Errorf("invalid PF name: %s", pf)
+				}
+				if name == iface.Name {
+					for _, group := range iface.VfGroups {
+						if sriovnetworkv1.IndexInRange(rngSt, group.VfRange) || sriovnetworkv1.IndexInRange(rngEnd, group.VfRange) {
+							if group.PolicyName != policy.GetName() {
+								return false, fmt.Errorf("Vf index range in %s is overlapped with existing policies", pf)
 							}
 						}
 					}

--- a/pkg/webhook/validate_test.go
+++ b/pkg/webhook/validate_test.go
@@ -132,9 +132,8 @@ func TestValidatePolicyForNodeStateWithOverlappedVfRange(t *testing.T) {
 		Spec: SriovNetworkNodePolicySpec{
 			DeviceType: "netdevice",
 			NicSelector: SriovNetworkNicSelector{
-				PfNames:     []string{"ens803f1#1-2"},
-				RootDevices: []string{"0000:86:00.1"},
-				Vendor:      "8086",
+				PfNames: []string{"ens803f1#1-2"},
+				Vendor:  "8086",
 			},
 			NodeSelector: map[string]string{
 				"feature.node.kubernetes.io/network-sriov.capable": "true",


### PR DESCRIPTION
Previously partition overlap was rejected only when
policy.Spec.NicSelector.RootDevices is configured.