### PR TITLE
Add discovery mode for sriov tests with shared policy

### DIFF
--- a/test/conformance/tests/sriov_operator.go
+++ b/test/conformance/tests/sriov_operator.go
@@ -17,7 +17,9 @@ import (
 	netattdefv1 "github.com/openshift/sriov-network-operator/pkg/apis/k8s/v1"
 	sriovv1 "github.com/openshift/sriov-network-operator/pkg/apis/sriovnetwork/v1"
 	"github.com/openshift/sriov-network-operator/test/util/cluster"
+	"github.com/openshift/sriov-network-operator/test/util/discovery"
 	"github.com/openshift/sriov-network-operator/test/util/execute"
+
 	"github.com/openshift/sriov-network-operator/test/util/namespaces"
 	"github.com/openshift/sriov-network-operator/test/util/network"
 	"github.com/openshift/sriov-network-operator/test/util/nodes"
@@ -71,7 +73,6 @@ var _ = Describe("[sriov] operator", func() {
 	})
 
 	Describe("No SriovNetworkNodePolicy", func() {
-
 		Context("SR-IOV network config daemon can be set by nodeselector", func() {
 			// 26186
 			It("Should schedule the config daemon on selected nodes", func() {
@@ -139,61 +140,35 @@ var _ = Describe("[sriov] operator", func() {
 		resourceName := "testresource"
 		var node string
 		var sriovDevice *sriovv1.InterfaceExt
+		var discoveryFailed bool
 
 		execute.BeforeAll(func() {
-			node = sriovInfos.Nodes[0]
 			var err error
+
+			if discovery.Enabled() {
+				node, resourceName, numVfs, err = discovery.DiscoveredResources(clients,
+					sriovInfos.Nodes, operatorNamespace, func(policy sriovv1.SriovNetworkNodePolicy) bool {
+						if policy.Spec.DeviceType != "netdevice" {
+							return false
+						}
+						return true
+					})
+
+				Expect(err).ToNot(HaveOccurred())
+				discoveryFailed = node == "" || resourceName == "" || numVfs < 5
+			} else {
+				node = sriovInfos.Nodes[0]
+				createVanillaNetworkPolicy(node, sriovInfos, numVfs, resourceName)
+				waitForSRIOVStable()
+			}
 			sriovDevice, err = sriovInfos.FindOneSriovDevice(node)
 			Expect(err).ToNot(HaveOccurred())
-
-			// For the context of tests is better to use a Mellanox card
-			// as they support all the virtual function flags
-			// if we don't find a Mellanox card we fall back to any sriov
-			// capability interface and skip the rate limit test.
-			intf, err := sriovInfos.FindOneMellanoxSriovDevice(node)
-			if err != nil {
-				intf, err = sriovInfos.FindOneSriovDevice(node)
-				Expect(err).ToNot(HaveOccurred())
-			}
-
-			config := &sriovv1.SriovNetworkNodePolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-policy",
-					Namespace:    operatorNamespace,
-				},
-
-				Spec: sriovv1.SriovNetworkNodePolicySpec{
-					NodeSelector: map[string]string{
-						"kubernetes.io/hostname": node,
-					},
-					NumVfs:       numVfs,
-					ResourceName: resourceName,
-					Priority:     99,
-					NicSelector: sriovv1.SriovNetworkNicSelector{
-						PfNames: []string{intf.Name},
-					},
-					DeviceType: "netdevice",
-				},
-			}
-
-			err = clients.Create(context.Background(), config)
-			Expect(err).ToNot(HaveOccurred())
-
-			Eventually(func() sriovv1.Interfaces {
-				nodeState, err := clients.SriovNetworkNodeStates(operatorNamespace).Get(context.Background(), node, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				return nodeState.Spec.Interfaces
-			}, 1*time.Minute, 1*time.Second).Should(ContainElement(MatchFields(
-				IgnoreExtras,
-				Fields{
-					"Name":   Equal(intf.Name),
-					"NumVfs": Equal(numVfs),
-				})))
-
-			waitForSRIOVStable()
 		})
 
 		BeforeEach(func() {
+			if discovery.Enabled() && discoveryFailed {
+				Skip("Insufficient resources to run tests in discovery mode")
+			}
 			err := namespaces.CleanPods(namespaces.Test, clients)
 			Expect(err).ToNot(HaveOccurred())
 			err = namespaces.CleanNetworks(operatorNamespace, clients)
@@ -262,7 +237,7 @@ var _ = Describe("[sriov] operator", func() {
 				Eventually(func() int64 {
 					testedNode, err := clients.Nodes().Get(context.Background(), node, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					resNum, _ := testedNode.Status.Allocatable["openshift.io/testresource"]
+					resNum, _ := testedNode.Status.Allocatable[corev1.ResourceName("openshift.io/"+resourceName)]
 					allocatable, _ := resNum.AsInt64()
 					return allocatable
 				}, 3*time.Minute, time.Second).Should(Equal(int64(numVfs)))
@@ -1595,4 +1570,49 @@ func waitForSRIOVStable() {
 		Expect(err).ToNot(HaveOccurred())
 		return isClusterReady
 	}, waitingTime, 1*time.Second).Should(BeTrue())
+}
+
+func createVanillaNetworkPolicy(node string, sriovInfos *cluster.EnabledNodes, numVfs int, resourceName string) {
+	// For the context of tests is better to use a Mellanox card
+	// as they support all the virtual function flags
+	// if we don't find a Mellanox card we fall back to any sriov
+	// capability interface and skip the rate limit test.
+	intf, err := sriovInfos.FindOneMellanoxSriovDevice(node)
+	if err != nil {
+		intf, err = sriovInfos.FindOneSriovDevice(node)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	config := &sriovv1.SriovNetworkNodePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-policy",
+			Namespace:    operatorNamespace,
+		},
+
+		Spec: sriovv1.SriovNetworkNodePolicySpec{
+			NodeSelector: map[string]string{
+				"kubernetes.io/hostname": node,
+			},
+			NumVfs:       numVfs,
+			ResourceName: resourceName,
+			Priority:     99,
+			NicSelector: sriovv1.SriovNetworkNicSelector{
+				PfNames: []string{intf.Name},
+			},
+			DeviceType: "netdevice",
+		},
+	}
+	err = clients.Create(context.Background(), config)
+	Expect(err).ToNot(HaveOccurred())
+
+	Eventually(func() sriovv1.Interfaces {
+		nodeState, err := clients.SriovNetworkNodeStates(operatorNamespace).Get(context.Background(), node, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		return nodeState.Spec.Interfaces
+	}, 1*time.Minute, 1*time.Second).Should(ContainElement(MatchFields(
+		IgnoreExtras,
+		Fields{
+			"Name":   Equal(intf.Name),
+			"NumVfs": Equal(numVfs),
+		})))
 }

--- a/test/util/cluster/cluster.go
+++ b/test/util/cluster/cluster.go
@@ -72,12 +72,18 @@ func (n *EnabledNodes) FindOneSriovDevice(node string) (*sriovv1.InterfaceExt, e
 	if !ok {
 		return nil, fmt.Errorf("Node %s not found", node)
 	}
+	var currentNumVfs int
+	var preferredIfc *sriovv1.InterfaceExt
 	for _, itf := range s.Status.Interfaces {
 		if IsDriverSupported(itf.Driver) && isDeviceSupported(itf.DeviceID) {
-			return &itf, nil
+			if itf.NumVfs > currentNumVfs {
+				preferredIfc = &itf
+			}
 		}
 	}
-
+	if preferredIfc != nil {
+		return preferredIfc, nil
+	}
 	return nil, fmt.Errorf("Unable to find sriov devices in node %s", node)
 }
 

--- a/test/util/discovery/discovery.go
+++ b/test/util/discovery/discovery.go
@@ -1,0 +1,71 @@
+package discovery
+
+import (
+	"context"
+	"os"
+	"strconv"
+
+	sriovv1 "github.com/openshift/sriov-network-operator/pkg/apis/sriovnetwork/v1"
+	"github.com/openshift/sriov-network-operator/test/util/client"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Enabled indicates whether test discovery mode is enabled.
+func Enabled() bool {
+	discoveryMode, _ := strconv.ParseBool(os.Getenv("DISCOVERY_MODE"))
+	return discoveryMode
+}
+
+// DiscoveredResources discovers resources needed by the tests in discovery mode
+func DiscoveredResources(clients *client.ClientSet, sriovNodes []string, operatorNamespace string, filter func(sriovv1.SriovNetworkNodePolicy) bool) (preferredNode string, preferredResourceName string, preferredResourceCount int, err error) {
+	policyList := sriovv1.SriovNetworkNodePolicyList{}
+	err = clients.List(context.Background(), &policyList, runtimeclient.InNamespace(operatorNamespace))
+	if err != nil {
+		return
+	}
+	nodes, err := getSriovNodes(clients, sriovNodes)
+	if err != nil {
+		return
+	}
+
+	for _, policy := range policyList.Items {
+		if !filter(policy) {
+			continue
+		}
+		resourceName := policy.Spec.ResourceName
+		for _, node := range nodes {
+			quantity := node.Status.Allocatable[corev1.ResourceName("openshift.io/"+resourceName)]
+			resourceCount64, _ := (&quantity).AsInt64()
+			resourceCount := int(resourceCount64)
+			if resourceCount > preferredResourceCount {
+				preferredResourceCount = resourceCount
+				preferredResourceName = resourceName
+				preferredNode = node.ObjectMeta.Name
+			}
+		}
+	}
+	return
+}
+
+func getSriovNodes(clients *client.ClientSet, sriovNodeNames []string) ([]corev1.Node, error) {
+	var nodes []corev1.Node
+	for _, sriovNodeName := range sriovNodeNames {
+		node, err := clients.Nodes().Get(context.Background(), sriovNodeName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, *node)
+	}
+	return nodes, nil
+}
+
+func containsNode(name string, sriovNodes []string) bool {
+	for _, node := range sriovNodes {
+		if node == name {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This patch adds a check for discovery mode and a resource check for tests with a shared policy.
Other tests will be covered in a follow up patch.