### PR TITLE
Add prerequisite about supported NIC model

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -2,8 +2,18 @@
 
 ## Prerequisites
 
-1. Kubernetes or Openshift cluster running on bare metal nodes.
-2. Multus-cni is deployed as default CNI plugin, and there is a default CNI plugin (flannel, openshift-sdn etc.) available for Multus-cni.
+1. A supported SRIOV hardware on the cluster nodes. Currently the supported models are:
+  
+   | Vendor-ID   | Device-ID   |
+   | ----------- | ----------- |
+   | Intel       | 158b        |
+   | Melanox     | 1015, 1017  |
+
+2. Kubernetes or Openshift cluster running on bare metal nodes.
+3. Multus-cni is deployed as default CNI plugin, and there is a default CNI plugin (flannel, openshift-sdn etc.) available for Multus-cni.
+
+> **Note:** As for unsupported SRIOV NICs, that is not guaranteed but might work as well.
+> For that to happen, one must [disable the webhook](https://docs.openshift.com/container-platform/4.4/networking/hardware_networks/configuring-sriov-operator.html#disable-enable-sr-iov-operator-admission-control-webhook_configuring-sriov-operator) which validates the NIC's model.
 
 ## Installation
 


### PR DESCRIPTION
- Add a clause to the Prerequisites section in the quick-start guide
about the supported models of SRIOV hardware.

- Add a note about the possibility of using unsupported models as well, by
  disabling the webhook for validating the NIC's model.

This could prevent frustration among users and developers
who do not understand why the SRIOV functionality is not working well,
and keep them aware that if their SRIOV NIC is not supported,
at least for development testing, they might be able to work around this.

Signed-off-by: alonSadan <asadan@redhat.com>