### PR TITLE
Revert changes to FindOneSriovDevice

### DIFF
--- a/test/util/cluster/cluster.go
+++ b/test/util/cluster/cluster.go
@@ -72,17 +72,10 @@ func (n *EnabledNodes) FindOneSriovDevice(node string) (*sriovv1.InterfaceExt, e
 	if !ok {
 		return nil, fmt.Errorf("Node %s not found", node)
 	}
-	var currentNumVfs int
-	var preferredIfc *sriovv1.InterfaceExt
 	for _, itf := range s.Status.Interfaces {
 		if IsDriverSupported(itf.Driver) && isDeviceSupported(itf.DeviceID) {
-			if itf.NumVfs > currentNumVfs {
-				preferredIfc = &itf
-			}
+			return &itf, nil
 		}
-	}
-	if preferredIfc != nil {
-		return preferredIfc, nil
 	}
 	return nil, fmt.Errorf("Unable to find sriov devices in node %s", node)
 }


### PR DESCRIPTION
cluster.FindOneSriovDevice was modified for discover mode to
return a device with biggest count of available vfs.
This check was since added to discovery.DiscoveredResources,
and is hence not needed here.
This change reverts the function to it's previous version