### PR TITLE
Remove ENABLE_ADMISSION_CONTROLLER in 4.5 manifests

### DIFF
--- a/manifests/4.5/sriov-network-operator.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/4.5/sriov-network-operator.v4.5.0.clusterserviceversion.yaml
@@ -282,8 +282,6 @@ spec:
                       value: quay.io/openshift/origin-sriov-network-webhook:4.5
                     - name: RESOURCE_PREFIX
                       value: openshift.io
-                    - name: ENABLE_ADMISSION_CONTROLLER
-                      value: "true"
                     - name: NAMESPACE
                       valueFrom:
                         fieldRef:


### PR DESCRIPTION
The issue of ENABLE_ADMISSION_CONTROLLER doesn't take effect
was fixed in 4.6/master branch. When that PR(https://github.com/openshift/sriov-network-operator/pull/211)
was proposed, 4.6 manifests were not created yet, so the change
went into 4.5 manifests(on 4.6 branch). This may cause confusion
that ENABLE_ADMISSION_CONTROLLER flag is supported in 4.5 release
which isn't true. This commit remove the env var change in 4.5
manifests(on 4.6 branch) to avoid confusion.