### PR TITLE
Bug 1870669: Fix the isInterfaceSlave function

### DIFF
--- a/test/conformance/tests/sriov_operator.go
+++ b/test/conformance/tests/sriov_operator.go
@@ -1489,7 +1489,7 @@ func isInterfaceSlave(ifcPod *k8sv1.Pod, ifcName string) (bool, error) {
 		parts := strings.Split(line, " ")
 		if len(parts) > 1 && parts[1] == ifcName {
 			if strings.Index(line, "master") != -1 { // Ignore hw bridges
-				return false, nil // The interface is part of a bridge (it has a master)
+				return true, nil // The interface is part of a bridge (it has a master)
 			}
 		}
 	}


### PR DESCRIPTION
This will fix the issue that the test kill the node by setting down the interface connected to the ovs external bridge

```
6: ens1f0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 master ovs-system hwmode VEPA
```

Signed-off-by: Sebastian Sch <sebassch@gmail.com>