### PR TITLE
Bug 1870547: Not update VF mtu if it's not retrievable or zero

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -144,7 +144,8 @@ func needUpdate(iface *sriovnetworkv1.Interface, ifaceStatus *sriovnetworkv1.Int
 		}
 	}
 	for _, vf := range ifaceStatus.VFs {
-		if vf.Mtu != mtu && !sriovnetworkv1.StringInArray(vf.Driver, DpdkDrivers) {
+		// 0 is a invalid value for mtu as defined in getNetdevMTU
+		if vf.Mtu != 0 && vf.Mtu != mtu && !sriovnetworkv1.StringInArray(vf.Driver, DpdkDrivers) {
 			glog.V(2).Infof("needUpdate(): VF MTU needs update, desired=%d", mtu)
 			return true
 		}


### PR DESCRIPTION
VF mtu may be discovered as zero if it's attached to a Pod
or not in the host namespace for various reasons.