### PR TITLE
Bug 1875330: Reset sync error if local status generation is equal remote.

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -361,6 +361,14 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 	latest := latestState.GetGeneration()
 	if dn.nodeState.GetGeneration() == latest {
 		glog.V(0).Infof("nodeStateSyncHandler(): Interface not changed")
+		if latestState.Status.LastSyncError != "" ||
+			latestState.Status.SyncStatus != "Succeeded" {
+			dn.refreshCh <- Message{
+				syncStatus:    "Succeeded",
+				lastSyncError: "",
+			}
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
When the fetch of the state fails, a sync error is written on the status.
Then, on next reconciliation loops, if the local generation equals to the remote one, that error is never reset. 
Here we assume that if the two versions are identical, the sync happened successfully and we reset the message.
