### PR TITLE
Add webhook delete operation

### DIFF
--- a/bindata/manifests/operator-webhook/003-webhook.yaml
+++ b/bindata/manifests/operator-webhook/003-webhook.yaml
@@ -33,7 +33,7 @@ webhooks:
         namespace: {{.Namespace}}
         path: "/validating-custom-resource"
     rules:
-      - operations: [ "CREATE", "UPDATE" ]
+      - operations: [ "CREATE", "UPDATE", "DELETE" ]
         apiGroups: ["sriovnetwork.openshift.io"]
         apiVersions: ["v1"]
         resources: ["sriovnetworknodepolicies"]

--- a/bindata/manifests/operator-webhook/003-webhook.yaml
+++ b/bindata/manifests/operator-webhook/003-webhook.yaml
@@ -36,4 +36,4 @@ webhooks:
       - operations: [ "CREATE", "UPDATE", "DELETE" ]
         apiGroups: ["sriovnetwork.openshift.io"]
         apiVersions: ["v1"]
-        resources: ["sriovnetworknodepolicies"]
+        resources: ["sriovnetworknodepolicies", "sriovoperatorconfigs"]

--- a/pkg/webhook/validate.go
+++ b/pkg/webhook/validate.go
@@ -26,6 +26,19 @@ var (
 	interfaceSelected bool
 )
 
+func validateSriovOperatorConfig(cr *sriovnetworkv1.SriovOperatorConfig, operation v1beta1.Operation) (bool, error) {
+	glog.V(2).Infof("validateSriovOperatorConfig: %v", cr)
+
+	if cr.GetName() == "default" {
+		if operation == "DELETE" {
+			return false, fmt.Errorf("default SriovOperatorConfig shouldn't be deleted")
+		} else {
+			return true, nil
+		}
+	}
+	return false, fmt.Errorf("only default SriovOperatorConfig is used")
+}
+
 func validateSriovNetworkNodePolicy(cr *sriovnetworkv1.SriovNetworkNodePolicy, operation v1beta1.Operation) (bool, error) {
 	glog.V(2).Infof("validateSriovNetworkNodePolicy: %v", cr)
 

--- a/pkg/webhook/validate_test.go
+++ b/pkg/webhook/validate_test.go
@@ -95,6 +95,34 @@ func newNodePolicy() *SriovNetworkNodePolicy {
 	}
 }
 
+func TestValidateSriovNetworkNodePolicyWithDefaultPolicy(t *testing.T) {
+	var err error
+	var ok bool
+	policy := &SriovNetworkNodePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+		Spec: SriovNetworkNodePolicySpec{
+			NicSelector:  SriovNetworkNicSelector{},
+			NodeSelector: map[string]string{},
+			NumVfs:       1,
+			ResourceName: "p0",
+		},
+	}
+	g := NewGomegaWithT(t)
+	ok, err = validateSriovNetworkNodePolicy(policy, "DELETE")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(ok).To(Equal(false))
+
+	ok, err = validateSriovNetworkNodePolicy(policy, "UPDATE")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ok).To(Equal(true))
+
+	ok, err = validateSriovNetworkNodePolicy(policy, "CREATE")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ok).To(Equal(true))
+}
+
 func TestValidatePolicyForNodeStateWithValidPolicy(t *testing.T) {
 	state := newNodeState()
 	policy := &SriovNetworkNodePolicy{

--- a/pkg/webhook/validate_test.go
+++ b/pkg/webhook/validate_test.go
@@ -95,6 +95,34 @@ func newNodePolicy() *SriovNetworkNodePolicy {
 	}
 }
 
+func TestValidateSriovOperatorConfigWithDefaultOperatorConfig(t *testing.T) {
+	var err error
+	var ok bool
+	config := &SriovOperatorConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+		Spec: SriovOperatorConfigSpec{
+			ConfigDaemonNodeSelector: map[string]string{},
+			EnableInjector:           func() *bool { b := true; return &b }(),
+			EnableOperatorWebhook:    func() *bool { b := true; return &b }(),
+			LogLevel:                 2,
+		},
+	}
+	g := NewGomegaWithT(t)
+	ok, err = validateSriovOperatorConfig(config, "DELETE")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(ok).To(Equal(false))
+
+	ok, err = validateSriovOperatorConfig(config, "UPDATE")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ok).To(Equal(true))
+
+	ok, err = validateSriovOperatorConfig(config, "CREATE")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ok).To(Equal(true))
+}
+
 func TestValidateSriovNetworkNodePolicyWithDefaultPolicy(t *testing.T) {
 	var err error
 	var ok bool

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -35,25 +35,44 @@ func MutateCustomResource(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse
 
 func ValidateCustomResource(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	glog.V(2).Info("validating custom resource")
-	cr := sriovnetworkv1.SriovNetworkNodePolicy{}
 	var err error
 	var raw []byte
+
 	raw = ar.Request.Object.Raw
-
-	err = json.Unmarshal(raw, &cr)
-	if err != nil {
-		glog.Error(err)
-		return toV1beta1AdmissionResponse(err)
-	}
-
 	reviewResponse := v1beta1.AdmissionResponse{}
 	reviewResponse.Allowed = true
 
-	if reviewResponse.Allowed, err = validateSriovNetworkNodePolicy(&cr, ar.Request.Operation); err != nil {
-		reviewResponse.Result = &metav1.Status{
-			Reason: metav1.StatusReason(err.Error()),
+	switch ar.Request.Kind.Kind {
+	case "SriovNetworkNodePolicy":
+		policy := sriovnetworkv1.SriovNetworkNodePolicy{}
+
+		err = json.Unmarshal(raw, &policy)
+		if err != nil {
+			glog.Error(err)
+			return toV1beta1AdmissionResponse(err)
+		}
+
+		if reviewResponse.Allowed, err = validateSriovNetworkNodePolicy(&policy, ar.Request.Operation); err != nil {
+			reviewResponse.Result = &metav1.Status{
+				Reason: metav1.StatusReason(err.Error()),
+			}
+		}
+	case "SriovOperatorConfig":
+		config := sriovnetworkv1.SriovOperatorConfig{}
+
+		err = json.Unmarshal(raw, &config)
+		if err != nil {
+			glog.Error(err)
+			return toV1beta1AdmissionResponse(err)
+		}
+
+		if reviewResponse.Allowed, err = validateSriovOperatorConfig(&config, ar.Request.Operation); err != nil {
+			reviewResponse.Result = &metav1.Status{
+				Reason: metav1.StatusReason(err.Error()),
+			}
 		}
 	}
+
 	return &reviewResponse
 }
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -49,7 +49,7 @@ func ValidateCustomResource(ar v1beta1.AdmissionReview) *v1beta1.AdmissionRespon
 	reviewResponse := v1beta1.AdmissionResponse{}
 	reviewResponse.Allowed = true
 
-	if reviewResponse.Allowed, err = validateSriovNetworkNodePolicy(&cr); err != nil {
+	if reviewResponse.Allowed, err = validateSriovNetworkNodePolicy(&cr, ar.Request.Operation); err != nil {
 		reviewResponse.Result = &metav1.Status{
 			Reason: metav1.StatusReason(err.Error()),
 		}


### PR DESCRIPTION
There are default sriovnetworknodepolicy and sriovoperatorconfig CRs
which we don't want user to delete although they can be re-created.
This PR adds support for DELETE operation in operator-webhook to
block the deletion of default node policy and operator config CRs.