### PR TITLE
Bug 1880990: Fix macvlan test

### DIFF
--- a/test/conformance/tests/sriov_operator.go
+++ b/test/conformance/tests/sriov_operator.go
@@ -689,9 +689,9 @@ var _ = Describe("[sriov] operator", func() {
 				macvlanNadName := "macvlan-nad"
 				nodeNicName := sriovInfos.States[node].Status.Interfaces[0].Name
 				macvlanNad := network.CreateMacvlanNetworkAttachmentDefinition(macvlanNadName, namespaces.Test, nodeNicName)
-				defer clients.Delete(context.Background(), &macvlanNad)
 				err = clients.Create(context.Background(), &macvlanNad)
 				Expect(err).ToNot(HaveOccurred())
+				defer clients.Delete(context.Background(), &macvlanNad)
 				Eventually(func() error {
 					netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 					return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: macvlanNadName, Namespace: namespaces.Test}, netAttDef)
@@ -707,7 +707,7 @@ var _ = Describe("[sriov] operator", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				sriovVfDriver := getDriver(stdout)
-				Expect(cluster.IsDriverSupported(sriovVfDriver)).To(BeTrue())
+				Expect(cluster.IsVFDriverSupported(sriovVfDriver)).To(BeTrue())
 
 				stdout, _, err = pod.ExecCommand(clients, createdPod, "ethtool", "-i", "net2")
 				macvlanDriver := getDriver(stdout)


### PR DESCRIPTION
Fix the macvlan test
    
This commit add a new list in the test for the VF drivers.
    
The issue with this test was that the VF drivers are not the same as the PF drivers for intel for example (mlx is the same)

This PR is base on https://github.com/openshift/sriov-network-operator/pull/345

Signed-off-by: Sebastian Sch <sebassch@gmail.com>
