### PR TITLE
Bug 1880990: Fix the pf down test

### DIFF
--- a/test/conformance/tests/sriov_operator.go
+++ b/test/conformance/tests/sriov_operator.go
@@ -1487,11 +1487,8 @@ func isInterfaceSlave(ifcPod *k8sv1.Pod, ifcName string) (bool, error) {
 	}
 	lines := strings.Split(stdout, "\n")
 	for _, line := range lines {
-		parts := strings.Split(line, " ")
-		if len(parts) > 1 && parts[1] == ifcName {
-			if strings.Index(line, "master") != -1 { // Ignore hw bridges
-				return true, nil // The interface is part of a bridge (it has a master)
-			}
+		if strings.Contains(line, ifcName) && strings.Contains(line, "master") {
+			return true, nil // The interface is part of a bridge (it has a master)
 		}
 	}
 	return false, nil


### PR DESCRIPTION
This commit change the search for the interface.
    
different base image versions like centos and ubi8 have a different outputs for the bridge link command.
    
This change will use the contains function and not search for the exact split string

Signed-off-by: Sebastian Sch <sebassch@gmail.com>
