### PR TITLE
Bug 1880990: Fix the MTU test

### DIFF
--- a/test/conformance/test_suite_test.go
+++ b/test/conformance/test_suite_test.go
@@ -56,6 +56,11 @@ func TestTest(t *testing.T) {
 	RunSpecsWithDefaultAndCustomReporters(t, "SRIOV Operator conformance tests", rr)
 }
 
+var _ = BeforeSuite(func() {
+	err := clean.All()
+	Expect(err).NotTo(HaveOccurred())
+})
+
 var _ = AfterSuite(func() {
 	err := clean.All()
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This commit changes the interface we use for the MTU test.

Is better not to use the main SDN interface for the MTU test,
because the test change the MTU of the PF to 9000 and packets start
dropping in the other nodes that have MTU set to 1500.

This commit also add the clean method to the beforeSuite function

Signed-off-by: Sebastian Sch <sebassch@gmail.com>