### PR TITLE
Bug 1878677: Adding a check to verify if skopeo is installed, otherwise exit 1

### DIFF
--- a/hack/env.sh
+++ b/hack/env.sh
@@ -1,3 +1,8 @@
+if ! skopeo -v &> /dev/null
+then
+        echo "skopeo could not be found"
+        exit 1
+fi
 CNI_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/openshift/origin-sriov-cni | jq --raw-output '.Digest')
 export SRIOV_CNI_IMAGE=${SRIOV_CNI_IMAGE:-quay.io/openshift/origin-sriov-cni@${CNI_IMAGE_DIGEST}}
 INFINIBAND_CNI_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/openshift/origin-sriov-infiniband-cni | jq --raw-output '.Digest')


### PR DESCRIPTION
Signed-off-by: Pedro Ibáñez <pedro@redhat.com>

If skopeo is not installed on the system the build succeed but the image name is incorrect and can't be pulled, this PR verifies if skopeo is installed, otherwise will exit with rc 1

Fixes #342