### PR TITLE
Bug 1880990: Skip vf allocation in case of discovery mode.

### DIFF
--- a/test/conformance/tests/sriov_operator.go
+++ b/test/conformance/tests/sriov_operator.go
@@ -729,6 +729,12 @@ var _ = Describe("[sriov] operator", func() {
 		})
 
 		Context("Virtual Functions", func() {
+			if discovery.Enabled() {
+				Skip("Virtual functions allocation test consumes all the available vfs, not suitable for discovery mode")
+				// TODO Split this so we check the allocation / unallocation but with a limited number of
+				// resources.
+			}
+
 			// 21396
 			It("should release the VFs once the pod deleted and same VFs can be used by the new created pods", func() {
 				By("Create first Pod which consumes all available VFs")


### PR DESCRIPTION
The test assumes a fixed number of available vfs, skipping for now.

