### PR TITLE
Bug 1880990: Move the skip inside an It context

### DIFF
--- a/test/conformance/tests/sriov_operator.go
+++ b/test/conformance/tests/sriov_operator.go
@@ -729,14 +729,14 @@ var _ = Describe("[sriov] operator", func() {
 		})
 
 		Context("Virtual Functions", func() {
-			if discovery.Enabled() {
-				Skip("Virtual functions allocation test consumes all the available vfs, not suitable for discovery mode")
-				// TODO Split this so we check the allocation / unallocation but with a limited number of
-				// resources.
-			}
-
 			// 21396
 			It("should release the VFs once the pod deleted and same VFs can be used by the new created pods", func() {
+				if discovery.Enabled() {
+					Skip("Virtual functions allocation test consumes all the available vfs, not suitable for discovery mode")
+					// TODO Split this so we check the allocation / unallocation but with a limited number of
+					// resources.
+				}
+
 				By("Create first Pod which consumes all available VFs")
 				sriovDevice, err := sriovInfos.FindOneSriovDevice(node)
 				ipam := `{"type": "host-local","ranges": [[{"subnet": "3ffe:ffff:0:01ff::/64"}]],"dataDir": "/run/my-orchestrator/container-ipam-state"}`


### PR DESCRIPTION
Without doing so, it causes a panic.

