### PR TITLE
Bug 1884251: Conformance test: make sure that the hostnetwork pod and the test pod run on the same node.

### DIFF
--- a/test/conformance/tests/sriov_operator.go
+++ b/test/conformance/tests/sriov_operator.go
@@ -264,7 +264,7 @@ var _ = Describe("[sriov] operator", func() {
 			intf := &sriovv1.InterfaceExt{}
 
 			validationFunction := func(networks []string, containsFunc func(line string) bool) {
-				podObj := pod.DefineWithNetworks(networks)
+				podObj := pod.RedefineWithNodeSelector(pod.DefineWithNetworks(networks), node)
 				err := clients.Create(context.Background(), podObj)
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(func() corev1.PodPhase {
@@ -318,7 +318,6 @@ var _ = Describe("[sriov] operator", func() {
 			}
 
 			BeforeEach(func() {
-				node := sriovInfos.Nodes[0]
 				Eventually(func() int64 {
 					testedNode, err := clients.Nodes().Get(context.Background(), node, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
In regular mode, this is ensured by the fact that we configure the devices only on the first node,
and as a side effect both pods get scheduled on the same node. This is not true in discovery mode
and with this change we ensure that.

