### PR TITLE
Updating sriov-network-must-gather builder & base images to be consistent with ART

### DIFF
--- a/must-gather/Dockerfile.rhel7
+++ b/must-gather/Dockerfile.rhel7
@@ -1,8 +1,8 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/openshift/sriov-network-operator
 COPY . .
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 LABEL io.k8s.display-name="sriov-network-operator-must-gather" \
       io.k8s.description="This is a sriov must-gather image that collectes sriov network operator related resources."
 COPY --from=builder /go/src/github.com/openshift/sriov-network-operator/must-gather/collection-scripts/* /usr/bin/


### PR DESCRIPTION
Updating sriov-network-must-gather builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/sriov-network-must-gather.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.