### PR TITLE
Add support for running in a virtual machine -- Remove PF dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ _build-%:
 _plugin-%: vet
 	@hack/build-plugins.sh $*
 
-plugins: _plugin-intel _plugin-mellanox _plugin-generic
+plugins: _plugin-intel _plugin-mellanox _plugin-generic _plugin-virtual
 
 clean:
 	@rm -rf $(TARGET_DIR)

--- a/cmd/sriov-network-config-daemon/start.go
+++ b/cmd/sriov-network-config-daemon/start.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -13,6 +15,7 @@ import (
 	"github.com/openshift/sriov-network-operator/pkg/daemon"
 	"github.com/openshift/sriov-network-operator/pkg/version"
 	"github.com/spf13/cobra"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -31,6 +34,11 @@ var (
 	startOpts struct {
 		kubeconfig string
 		nodeName   string
+	}
+
+	// PlatformMap contains supported platforms for virtual VF
+	platformMap = map[string]daemon.PlatformType{
+		"openstack": daemon.Virtual,
 	}
 )
 
@@ -107,9 +115,23 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		destdir = "/host/etc"
 	}
 
+	platformType := daemon.Baremetal
+
+	nodeInfo, err := kubeclient.CoreV1().Nodes().Get(context.Background(), startOpts.nodeName, v1.GetOptions{})
+	if err == nil {
+		for key, pType := range platformMap {
+			if strings.Contains(strings.ToLower(nodeInfo.Spec.ProviderID), strings.ToLower(key)) {
+				platformType = pType
+			}
+		}
+	} else {
+		glog.Warningf("Failed to fetch node state %s, %v!", startOpts.nodeName, err)
+	}
+	glog.V(0).Infof("Running on platform: %s", platformType.String())
+
 	// block the deamon process until nodeWriter finish first its run
-	nodeWriter.Run(stopCh, refreshCh, syncCh, destdir, true)
-	go nodeWriter.Run(stopCh, refreshCh, syncCh, "", false)
+	nodeWriter.Run(stopCh, refreshCh, syncCh, destdir, true, platformType)
+	go nodeWriter.Run(stopCh, refreshCh, syncCh, "", false, platformType)
 
 	glog.V(0).Info("Starting SriovNetworkConfigDaemon")
 	err = daemon.New(
@@ -120,6 +142,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		stopCh,
 		syncCh,
 		refreshCh,
+		platformType,
 	).Run(stopCh, exitCh)
 	if err != nil {
 		glog.Errorf("failed to run daemon: %v", err)

--- a/pkg/daemon/plugin.go
+++ b/pkg/daemon/plugin.go
@@ -22,9 +22,8 @@ type VendorPlugin interface {
 }
 
 var pluginMap = map[string]string{
-	"8086":    "intel_plugin",
-	"15b3":    "mellanox_plugin",
-	"virtual": "virtual_plugin",
+	"8086": "intel_plugin",
+	"15b3": "mellanox_plugin",
 }
 
 const (

--- a/pkg/daemon/plugin.go
+++ b/pkg/daemon/plugin.go
@@ -22,13 +22,15 @@ type VendorPlugin interface {
 }
 
 var pluginMap = map[string]string{
-	"8086": "intel_plugin",
-	"15b3": "mellanox_plugin",
+	"8086":    "intel_plugin",
+	"15b3":    "mellanox_plugin",
+	"virtual": "virtual_plugin",
 }
 
 const (
 	SpecVersion   = "1.0"
 	GenericPlugin = "generic_plugin"
+	VirtualPlugin = "virtual_plugin"
 )
 
 // loadPlugin loads a single plugin from a file path

--- a/pkg/plugins/virtual/virtual_plugin.go
+++ b/pkg/plugins/virtual/virtual_plugin.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"os/exec"
+	"reflect"
+	"syscall"
+
+	"github.com/golang/glog"
+	sriovnetworkv1 "github.com/openshift/sriov-network-operator/api/v1"
+	"github.com/openshift/sriov-network-operator/pkg/utils"
+)
+
+// VirtualPlugin Plugin type to use on a virtual platform
+type VirtualPlugin struct {
+	PluginName     string
+	SpecVersion    string
+	DesireState    *sriovnetworkv1.SriovNetworkNodeState
+	LastState      *sriovnetworkv1.SriovNetworkNodeState
+	LoadVfioDriver uint
+}
+
+const (
+	unloaded = iota
+	loading
+	loaded
+)
+
+// Plugin VirtualPlugin type
+var Plugin VirtualPlugin
+
+// Initialize our plugin and set up initial values
+func init() {
+	Plugin = VirtualPlugin{
+		PluginName:     "virtual_plugin",
+		SpecVersion:    "1.0",
+		LoadVfioDriver: unloaded,
+	}
+}
+
+// Name returns the name of the plugin
+func (p *VirtualPlugin) Name() string {
+	return p.PluginName
+}
+
+// Spec returns the version of the spec expected by the plugin
+func (p *VirtualPlugin) Spec() string {
+	return p.SpecVersion
+}
+
+// OnNodeStateAdd Invoked when SriovNetworkNodeState CR is created, return if need dain and/or reboot node
+func (p *VirtualPlugin) OnNodeStateAdd(state *sriovnetworkv1.SriovNetworkNodeState) (needDrain bool, needReboot bool, err error) {
+	glog.Info("virtual-plugin OnNodeStateAdd()")
+	needDrain = false
+	needReboot = false
+	err = nil
+	p.DesireState = state
+
+	needDrain = needDrainNode(state.Spec.Interfaces, state.Status.Interfaces)
+
+	if p.LoadVfioDriver != loaded {
+		if needVfioDriver(state) {
+			p.LoadVfioDriver = loading
+		}
+	}
+	return
+}
+
+// OnNodeStateChange Invoked when SriovNetworkNodeState CR is updated, return if need dain and/or reboot node
+func (p *VirtualPlugin) OnNodeStateChange(old, new *sriovnetworkv1.SriovNetworkNodeState) (needDrain bool, needReboot bool, err error) {
+	glog.Info("virtual-plugin OnNodeStateChange()")
+	needDrain = false
+	needReboot = false
+	err = nil
+	p.DesireState = new
+
+	if p.LoadVfioDriver != loaded {
+		if needVfioDriver(new) {
+			p.LoadVfioDriver = loading
+		}
+	}
+
+	return
+}
+
+// Apply config change
+func (p *VirtualPlugin) Apply() error {
+	glog.Infof("virtual-plugin Apply(): desiredState=%v", p.DesireState.Spec)
+
+	if p.LoadVfioDriver == loading {
+		if err := utils.LoadKernelModule("vfio_pci"); err != nil {
+			glog.Errorf("virtual-plugin Apply(): fail to load vfio_pci kmod: %v", err)
+			return err
+		}
+		p.LoadVfioDriver = loaded
+	}
+
+	if p.LastState != nil {
+		glog.Infof("virtual-plugin Apply(): lastStat=%v", p.LastState.Spec)
+		if reflect.DeepEqual(p.LastState.Spec.Interfaces, p.DesireState.Spec.Interfaces) {
+			glog.Info("virtual-plugin Apply(): nothing to apply")
+			return nil
+		}
+	}
+	exit, err := utils.Chroot("/host")
+	if err != nil {
+		return err
+	}
+	defer exit()
+	if err := utils.SyncNodeStateVirtual(p.DesireState); err != nil {
+		return err
+	}
+	p.LastState = &sriovnetworkv1.SriovNetworkNodeState{}
+	*p.LastState = *p.DesireState
+
+	return nil
+}
+
+func needVfioDriver(state *sriovnetworkv1.SriovNetworkNodeState) bool {
+	for _, iface := range state.Spec.Interfaces {
+		for i := range iface.VfGroups {
+			if iface.VfGroups[i].DeviceType == "vfio-pci" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isCommandNotFound(err error) bool {
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.ExitStatus() == 127 {
+			return true
+		}
+	}
+	return false
+}
+
+func needDrainNode(desired sriovnetworkv1.Interfaces, current sriovnetworkv1.InterfaceExts) (needDrain bool) {
+	needDrain = false
+	return
+}

--- a/pkg/plugins/virtual/virtual_plugin.go
+++ b/pkg/plugins/virtual/virtual_plugin.go
@@ -50,12 +50,9 @@ func (p *VirtualPlugin) Spec() string {
 // OnNodeStateAdd Invoked when SriovNetworkNodeState CR is created, return if need dain and/or reboot node
 func (p *VirtualPlugin) OnNodeStateAdd(state *sriovnetworkv1.SriovNetworkNodeState) (needDrain bool, needReboot bool, err error) {
 	glog.Info("virtual-plugin OnNodeStateAdd()")
-	needDrain = false
 	needReboot = false
 	err = nil
 	p.DesireState = state
-
-	needDrain = needDrainNode(state.Spec.Interfaces, state.Status.Interfaces)
 
 	if p.LoadVfioDriver != loaded {
 		if needVfioDriver(state) {
@@ -133,9 +130,4 @@ func isCommandNotFound(err error) bool {
 		}
 	}
 	return false
-}
-
-func needDrainNode(desired sriovnetworkv1.Interfaces, current sriovnetworkv1.InterfaceExts) (needDrain bool) {
-	needDrain = false
-	return
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -111,6 +111,8 @@ func DiscoverSriovDevices() ([]sriovnetworkv1.InterfaceExt, error) {
 	return pfList, nil
 }
 
+// SyncNodeState Attempt to update the node state to match the desired state
+//
 func SyncNodeState(newState *sriovnetworkv1.SriovNetworkNodeState) error {
 	var err error
 	for _, ifaceStatus := range newState.Status.Interfaces {

--- a/pkg/utils/utils_virtual.go
+++ b/pkg/utils/utils_virtual.go
@@ -1,0 +1,179 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/golang/glog"
+	dputils "github.com/intel/sriov-network-device-plugin/pkg/utils"
+	"github.com/jaypipes/ghw"
+	sriovnetworkv1 "github.com/openshift/sriov-network-operator/api/v1"
+)
+
+// DiscoverSriovDevicesVirtual discovers VFs on a virtual platform
+func DiscoverSriovDevicesVirtual() ([]sriovnetworkv1.InterfaceExt, error) {
+	glog.V(2).Info("DiscoverSriovDevicesVirtual")
+	pfList := []sriovnetworkv1.InterfaceExt{}
+
+	pci, err := ghw.PCI()
+	if err != nil {
+		return nil, fmt.Errorf("DiscoverSriovDevicesVirtual(): error getting PCI info: %v", err)
+	}
+
+	devices := pci.ListDevices()
+	if len(devices) == 0 {
+		return nil, fmt.Errorf("DiscoverSriovDevicesVirtual(): could not retrieve PCI devices")
+	}
+
+	for _, device := range devices {
+		devClass, err := strconv.ParseInt(device.Class.ID, 16, 64)
+		if err != nil {
+			glog.Warningf("DiscoverSriovDevicesVirtual(): unable to parse device class for device %+v %q", device, err)
+			continue
+		}
+		if devClass != netClass {
+			// Not network device
+			continue
+		}
+
+		driver, err := dputils.GetDriverName(device.Address)
+		if err != nil {
+			glog.Warningf("DiscoverSriovDevicesVirtual(): unable to parse device driver for device %+v %q", device, err)
+			continue
+		}
+		iface := sriovnetworkv1.InterfaceExt{
+			PciAddress: device.Address,
+			Driver:     driver,
+			Vendor:     device.Vendor.ID,
+			DeviceID:   device.Product.ID,
+		}
+		if mtu := getNetdevMTU(device.Address); mtu > 0 {
+			iface.Mtu = mtu
+		}
+		if name := tryGetInterfaceName(device.Address); name != "" {
+			iface.Name = name
+			iface.Mac = getNetDevMac(name)
+			iface.LinkSpeed = getNetDevLinkSpeed(name)
+		}
+		iface.LinkType = getLinkType(iface)
+
+		iface.TotalVfs = 1
+		iface.NumVfs = 1
+
+		vf := sriovnetworkv1.VirtualFunction{
+			PciAddress: device.Address,
+			Driver:     driver,
+			VfID:       0,
+			Vendor:     iface.Vendor,
+			DeviceID:   iface.DeviceID,
+			Mtu:        iface.Mtu,
+			Mac:        iface.Mac,
+		}
+		iface.VFs = append(iface.VFs, vf)
+
+		pfList = append(pfList, iface)
+	}
+	return pfList, nil
+}
+
+// SyncNodeStateVirtual attempt to update the node state to match the desired state
+//  in virtual platforms
+func SyncNodeStateVirtual(newState *sriovnetworkv1.SriovNetworkNodeState) error {
+	var err error
+	for _, ifaceStatus := range newState.Status.Interfaces {
+		for _, iface := range newState.Spec.Interfaces {
+			if iface.PciAddress == ifaceStatus.PciAddress {
+				if !needUpdateVirtual(&iface, &ifaceStatus) {
+					glog.V(2).Infof("SyncNodeStateVirtual(): no need update interface %s", iface.PciAddress)
+					break
+				}
+				if err = configSriovDeviceVirtual(&iface, &ifaceStatus); err != nil {
+					glog.Errorf("SyncNodeStateVirtual(): fail to config sriov interface %s: %v", iface.PciAddress, err)
+					return err
+				}
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func needUpdateVirtual(iface *sriovnetworkv1.Interface, ifaceStatus *sriovnetworkv1.InterfaceExt) bool {
+	// The device MTU is set by the platorm
+	// The NumVfs is always 1
+	if iface.NumVfs > 0 {
+		for _, vf := range ifaceStatus.VFs {
+			ingroup := false
+			for _, group := range iface.VfGroups {
+				if sriovnetworkv1.IndexInRange(vf.VfID, group.VfRange) {
+					ingroup = true
+					if group.DeviceType != "netdevice" {
+						if group.DeviceType != vf.Driver {
+							glog.V(2).Infof("needUpdateVirtual(): Driver needs update, desired=%s, current=%s", group.DeviceType, vf.Driver)
+							return true
+						}
+					} else {
+						if sriovnetworkv1.StringInArray(vf.Driver, DpdkDrivers) {
+							glog.V(2).Infof("needUpdateVirtual(): Driver needs update, desired=%s, current=%s", group.DeviceType, vf.Driver)
+							return true
+						}
+					}
+					break
+				}
+			}
+			if !ingroup && sriovnetworkv1.StringInArray(vf.Driver, DpdkDrivers) {
+				// VF which has DPDK driver loaded but not in any group, needs to be reset to default driver.
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func configSriovDeviceVirtual(iface *sriovnetworkv1.Interface, ifaceStatus *sriovnetworkv1.InterfaceExt) error {
+	glog.V(2).Infof("configSriovDeviceVirtual(): config interface %s with %v", iface.PciAddress, iface)
+	// Config VFs
+	if iface.NumVfs > 0 {
+		if iface.NumVfs > 1 {
+			glog.Warningf("configSriovDeviceVirtual(): in a virtual environment, only one VF per interface (NumVfs: %d)", iface.NumVfs)
+			return errors.New("NumVfs > 1")
+		}
+		if len(iface.VfGroups) != 1 {
+			glog.Warningf("configSriovDeviceVirtual(): missing VFGroup")
+			return errors.New("NumVfs != 1")
+		}
+		vfAddrs := []string{iface.PciAddress}
+		glog.V(2).Infof("configSriovDeviceVirtual(): vfaddrs %v", vfAddrs)
+		for _, addr := range vfAddrs {
+			glog.V(2).Infof("configSriovDeviceVirtual(): addr %s", addr)
+			driver := ""
+			vfID := 0
+			for _, group := range iface.VfGroups {
+				glog.V(2).Infof("configSriovDeviceVirtual(): group %v", group)
+				if sriovnetworkv1.IndexInRange(vfID, group.VfRange) {
+					glog.V(2).Infof("configSriovDeviceVirtual(): indexInRange %d", vfID)
+					if sriovnetworkv1.StringInArray(group.DeviceType, DpdkDrivers) {
+						glog.V(2).Infof("configSriovDeviceVirtual(): driver %s", group.DeviceType)
+						driver = group.DeviceType
+					}
+					break
+				}
+			}
+			if driver == "" {
+				glog.V(2).Infof("configSriovDeviceVirtual(): bind default")
+				if err := BindDefaultDriver(addr); err != nil {
+					glog.Warningf("configSriovDeviceVirtual(): fail to bind default driver for device %s", addr)
+					return err
+				}
+			} else {
+				glog.V(2).Infof("configSriovDeviceVirtual(): bind driver %s", driver)
+				if err := BindDpdkDriver(addr, driver); err != nil {
+					glog.Warningf("configSriovDeviceVirtual(): fail to bind driver %s for device %s", driver, addr)
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/utils/utils_virtual.go
+++ b/pkg/utils/utils_virtual.go
@@ -143,35 +143,32 @@ func configSriovDeviceVirtual(iface *sriovnetworkv1.Interface, ifaceStatus *srio
 			glog.Warningf("configSriovDeviceVirtual(): missing VFGroup")
 			return errors.New("NumVfs != 1")
 		}
-		vfAddrs := []string{iface.PciAddress}
-		glog.V(2).Infof("configSriovDeviceVirtual(): vfaddrs %v", vfAddrs)
-		for _, addr := range vfAddrs {
-			glog.V(2).Infof("configSriovDeviceVirtual(): addr %s", addr)
-			driver := ""
-			vfID := 0
-			for _, group := range iface.VfGroups {
-				glog.V(2).Infof("configSriovDeviceVirtual(): group %v", group)
-				if sriovnetworkv1.IndexInRange(vfID, group.VfRange) {
-					glog.V(2).Infof("configSriovDeviceVirtual(): indexInRange %d", vfID)
-					if sriovnetworkv1.StringInArray(group.DeviceType, DpdkDrivers) {
-						glog.V(2).Infof("configSriovDeviceVirtual(): driver %s", group.DeviceType)
-						driver = group.DeviceType
-					}
-					break
+		addr := iface.PciAddress
+		glog.V(2).Infof("configSriovDeviceVirtual(): addr %s", addr)
+		driver := ""
+		vfID := 0
+		for _, group := range iface.VfGroups {
+			glog.V(2).Infof("configSriovDeviceVirtual(): group %v", group)
+			if sriovnetworkv1.IndexInRange(vfID, group.VfRange) {
+				glog.V(2).Infof("configSriovDeviceVirtual(): indexInRange %d", vfID)
+				if sriovnetworkv1.StringInArray(group.DeviceType, DpdkDrivers) {
+					glog.V(2).Infof("configSriovDeviceVirtual(): driver %s", group.DeviceType)
+					driver = group.DeviceType
 				}
+				break
 			}
-			if driver == "" {
-				glog.V(2).Infof("configSriovDeviceVirtual(): bind default")
-				if err := BindDefaultDriver(addr); err != nil {
-					glog.Warningf("configSriovDeviceVirtual(): fail to bind default driver for device %s", addr)
-					return err
-				}
-			} else {
-				glog.V(2).Infof("configSriovDeviceVirtual(): bind driver %s", driver)
-				if err := BindDpdkDriver(addr, driver); err != nil {
-					glog.Warningf("configSriovDeviceVirtual(): fail to bind driver %s for device %s", driver, addr)
-					return err
-				}
+		}
+		if driver == "" {
+			glog.V(2).Infof("configSriovDeviceVirtual(): bind default")
+			if err := BindDefaultDriver(addr); err != nil {
+				glog.Warningf("configSriovDeviceVirtual(): fail to bind default driver for device %s", addr)
+				return err
+			}
+		} else {
+			glog.V(2).Infof("configSriovDeviceVirtual(): bind driver %s", driver)
+			if err := BindDpdkDriver(addr, driver); err != nil {
+				glog.Warningf("configSriovDeviceVirtual(): fail to bind driver %s for device %s", driver, addr)
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds support for running (initially) in an OpenShift on OpenStack environment.  In a VM environment, only VFs are attached (no PF) and the VFs represent an underlying OpenStack network.  This PR removes the necessity of accessing a PF and uses additional information passed into the VM by the OpenStack metadata service to include underlying network mappings in the sriovnetworknodestate.  In addition, the exposed underlying network information can be used to select networks for a policy.  

This PR is in conjunction with a PR in  k8snetworkplumbingwg/sriov-network-device-plugin repository.  

This PR is to allow a review of the concept.
