### PR TITLE
Bug 1879379: Use cli base image for must-gather image building

### DIFF
--- a/must-gather/Dockerfile.rhel7
+++ b/must-gather/Dockerfile.rhel7
@@ -2,7 +2,7 @@ FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 
 WORKDIR /go/src/github.com/openshift/sriov-network-operator
 COPY . .
 
-FROM registry.svc.ci.openshift.org/ocp/4.7:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:cli
 LABEL io.k8s.display-name="sriov-network-operator-must-gather" \
       io.k8s.description="This is a sriov must-gather image that collectes sriov network operator related resources."
 COPY --from=builder /go/src/github.com/openshift/sriov-network-operator/must-gather/collection-scripts/* /usr/bin/


### PR DESCRIPTION
PR #343 reverts the must-gather base image from cli to base.
This is to change it back.