### PR TITLE
Add an optional SriovNetwork section: additional metaplugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,45 @@ spec:
   resourceName: intelnics
 ```
 
+#### Chaining CNI metaplugins
+
+It is possible to add additional capabilities to the device configured via the SR-IOV configuring optional metaplugins.
+
+In order to do this, the `metaPlugins` field must contain the array of one or more additional configurations used to build a [network configuration list](https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration-lists), as per the following example:
+
+```yaml
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: example-network
+  namespace: example-namespace
+spec:
+  ipam: |
+    {
+      "type": "host-local",
+      "subnet": "10.56.217.0/24",
+      "rangeStart": "10.56.217.171",
+      "rangeEnd": "10.56.217.181",
+      "routes": [{
+        "dst": "0.0.0.0/0"
+      }],
+      "gateway": "10.56.217.1"
+    }
+  vlan: 0
+  resourceName: intelnics
+  metaPlugins : |
+    {
+      "type": "tuning",
+      "sysctl": {
+        "net.core.somaxconn": "500"
+      }
+    },
+    {
+      "type": "vrf",
+      "vrfname": "red"
+    }
+```
+
 ### SriovNetworkNodeState
 
 The custom resource to represent the SR-IOV interface states of each host, which should only be managed by the operator itself.

--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -19,13 +19,13 @@ import (
 )
 
 const (
-	MANIFESTS_PATH       = "./bindata/manifests/cni-config"
 	LASTNETWORKNAMESPACE = "operator.sriovnetwork.openshift.io/last-network-namespace"
 	FINALIZERNAME        = "netattdef.finalizers.sriovnetwork.openshift.io"
 )
 
 const invalidVfIndex = -1
 
+var MANIFESTS_PATH = "./bindata/manifests/cni-config"
 var log = logf.Log.WithName("sriovnetwork")
 var VfIds = []string{}
 
@@ -493,6 +493,12 @@ func (cr *SriovNetwork) RenderNetAttDef() (*uns.Unstructured, error) {
 		data.Data["SriovCniIpam"] = "\"ipam\":" + strings.Join(strings.Fields(cr.Spec.IPAM), "")
 	} else {
 		data.Data["SriovCniIpam"] = "\"ipam\":{}"
+	}
+
+	data.Data["MetaPluginsConfigured"] = false
+	if cr.Spec.MetaPluginsConfig != "" {
+		data.Data["MetaPluginsConfigured"] = true
+		data.Data["MetaPlugins"] = cr.Spec.MetaPluginsConfig
 	}
 
 	objs, err = render.RenderDir(MANIFESTS_PATH, &data)

--- a/api/v1/helper_test.go
+++ b/api/v1/helper_test.go
@@ -1,0 +1,81 @@
+package v1_test
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"flag"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	v1 "github.com/openshift/sriov-network-operator/api/v1"
+)
+
+var update = flag.Bool("updategolden", false, "update .golden files")
+
+func init() {
+	// when running go tests path is local to the file, overriding it.
+	v1.MANIFESTS_PATH = "../../bindata/manifests/cni-config"
+}
+
+func TestRendering(t *testing.T) {
+	testtable := []struct {
+		tname   string
+		network v1.SriovNetwork
+	}{
+		{
+			tname: "simple",
+			network: v1.SriovNetwork{
+				Spec: v1.SriovNetworkSpec{
+					NetworkNamespace: "testnamespace",
+					ResourceName:     "testresource",
+				},
+			},
+		},
+		{
+			tname: "chained",
+			network: v1.SriovNetwork{
+				Spec: v1.SriovNetworkSpec{
+					NetworkNamespace: "testnamespace",
+					ResourceName:     "testresource",
+					MetaPluginsConfig: `
+					{
+						"type": "vrf",
+						"vrfname": "blue"
+					}
+					`,
+				},
+			},
+		},
+	}
+	for _, tc := range testtable {
+		t.Run(tc.tname, func(t *testing.T) {
+			var b bytes.Buffer
+			w := bufio.NewWriter(&b)
+			rendered, err := tc.network.RenderNetAttDef()
+			if err != nil {
+				t.Fatal("failed rendering network attachment definition", err)
+			}
+			encoder := json.NewEncoder(w)
+			encoder.SetIndent("", "  ")
+			encoder.Encode(rendered)
+			w.Flush()
+			gp := filepath.Join("testdata", filepath.FromSlash(t.Name())+".golden")
+			if *update {
+				t.Log("update golden file")
+				if err := ioutil.WriteFile(gp, b.Bytes(), 0644); err != nil {
+					t.Fatalf("failed to update golden file: %s", err)
+				}
+			}
+			g, err := ioutil.ReadFile(gp)
+			if err != nil {
+				t.Fatalf("failed reading .golden: %s", err)
+			}
+			t.Log(string(b.Bytes()))
+			if !bytes.Equal(b.Bytes(), g) {
+				t.Errorf("bytes do not match .golden file")
+			}
+		})
+	}
+}

--- a/api/v1/sriovnetwork_types.go
+++ b/api/v1/sriovnetwork_types.go
@@ -42,6 +42,9 @@ type SriovNetworkSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	// Maximum tx rate, in Mbps, for the VF. Defaults to 0 (no rate limiting)
 	MaxTxRate *int `json:"maxTxRate,omitempty"`
+	// MetaPluginsConfig configuration to be used in order to chain metaplugins to the sriov interface returned
+	// by the operator.
+	MetaPluginsConfig string `json:"metaplugins,omitempty"`
 }
 
 // SriovNetworkStatus defines the observed state of SriovNetwork

--- a/api/v1/testdata/TestRendering/chained.golden
+++ b/api/v1/testdata/TestRendering/chained.golden
@@ -1,0 +1,14 @@
+{
+  "apiVersion": "k8s.cni.cncf.io/v1",
+  "kind": "NetworkAttachmentDefinition",
+  "metadata": {
+    "annotations": {
+      "k8s.v1.cni.cncf.io/resourceName": "/testresource"
+    },
+    "name": null,
+    "namespace": "testnamespace"
+  },
+  "spec": {
+    "config": "{\"cniVersion\":\"0.4.0\",\"name\":\"\",\"plugins\": [ {\"type\":\"sriov\",\"vlan\":0,\"vlanQoS\":0,\"ipam\":{} },\n{ \"type\": \"vrf\", \"vrfname\": \"blue\" }\n]"
+  }
+}

--- a/api/v1/testdata/TestRendering/simple.golden
+++ b/api/v1/testdata/TestRendering/simple.golden
@@ -1,0 +1,14 @@
+{
+  "apiVersion": "k8s.cni.cncf.io/v1",
+  "kind": "NetworkAttachmentDefinition",
+  "metadata": {
+    "annotations": {
+      "k8s.v1.cni.cncf.io/resourceName": "/testresource"
+    },
+    "name": null,
+    "namespace": "testnamespace"
+  },
+  "spec": {
+    "config": "{\"cniVersion\":\"0.3.1\",\"name\":\"\",\"type\":\"sriov\",\"vlan\":0,\"vlanQoS\":0,\"ipam\":{} }"
+  }
+}

--- a/bindata/manifests/cni-config/sriov-cni-config.yaml
+++ b/bindata/manifests/cni-config/sriov-cni-config.yaml
@@ -9,6 +9,10 @@ spec:
   config: '{
   "cniVersion":"0.3.1",
   "name":"{{.SriovNetworkName}}",
+{{- if .MetaPluginsConfigured -}}
+  "plugins": [
+    {
+{{- end -}}
   "type":"{{.CniType}}",
 {{- if eq .CniType "sriov" -}}
   "vlan":{{.SriovCniVlan}},
@@ -35,4 +39,11 @@ spec:
   "link_state":"{{.SriovCniState}}",
 {{- end -}}
   {{.SriovCniIpam}}
-}'
+}
+{{- if .MetaPluginsConfigured -}}
+  ,
+  {{.MetaPlugins}}
+  ]
+}
+{{- end -}}
+'

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworks.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworks.yaml
@@ -55,6 +55,10 @@ spec:
                   rate limiting)
                 minimum: 0
                 type: integer
+              metaplugins:
+                description: MetaPluginsConfig configuration to be used in order to
+                  chain metaplugins to the sriov interface returned by the operator.
+                type: string
               minTxRate:
                 description: Minimum tx rate, in Mbps, for the VF. Defaults to 0 (no
                   rate limiting). min_tx_rate should be <= max_tx_rate.

--- a/manifests/4.7/sriov-network-operator-sriovnetwork.crd.yaml
+++ b/manifests/4.7/sriov-network-operator-sriovnetwork.crd.yaml
@@ -60,6 +60,9 @@ spec:
                   rate limiting). min_tx_rate should be <= max_tx_rate.
                 minimum: 0
                 type: integer
+              metaPlugins:
+                  description: MetaPlugins configurations to be chained to the SR-IOV cni configuration.
+                  type: string
               networkNamespace:
                 description: Namespace of the NetworkAttachmentDefinition custom resource
                 type: string

--- a/test/util/network/network.go
+++ b/test/util/network/network.go
@@ -19,7 +19,9 @@ type Network struct {
 	Ips       []string
 }
 
-func CreateSriovNetwork(clientSet *testclient.ClientSet, intf *sriovv1.InterfaceExt, name string, namespace string, operatorNamespace string, resourceName string, ipam string) error {
+type SriovNetworkOptions func(*sriovv1.SriovNetwork)
+
+func CreateSriovNetwork(clientSet *testclient.ClientSet, intf *sriovv1.InterfaceExt, name string, namespace string, operatorNamespace string, resourceName string, ipam string, options ...SriovNetworkOptions) error {
 	sriovNetwork := &sriovv1.SriovNetwork{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -30,6 +32,10 @@ func CreateSriovNetwork(clientSet *testclient.ClientSet, intf *sriovv1.Interface
 			IPAM:             ipam,
 			NetworkNamespace: namespace,
 		}}
+
+	for _, o := range options {
+		o(sriovNetwork)
+	}
 
 	// We need this to be able to run the connectivity checks on Mellanox cards
 	if intf.DeviceID == "1015" {


### PR DESCRIPTION
In order to generate a network attachment definition that chains the SR-IOV CNI configuration with additional metaplugins (such as VRF, or firewall), we expose a new MetaPluginsConfig where to put the json list of the extra configurations, in the form of

```
{
	// meta plugin A config
},
{
	// meta plugin B config
}
```
