### PR TITLE
Add DisableDrain flag into operator config for efficient debugging

### DIFF
--- a/api/v1/sriovoperatorconfig_types.go
+++ b/api/v1/sriovoperatorconfig_types.go
@@ -20,6 +20,8 @@ type SriovOperatorConfigSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=2
 	LogLevel int `json:"logLevel,omitempty"`
+	// Flag to disable nodes drain during debugging
+	DisableDrain bool `json:"disableDrain,omitempty"`
 }
 
 // SriovOperatorConfigStatus defines the observed state of SriovOperatorConfig

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovoperatorconfigs.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovoperatorconfigs.yaml
@@ -42,6 +42,9 @@ spec:
                   type: string
                 description: NodeSelector selects the nodes to be configured
                 type: object
+              disableDrain:
+                description: Flag to disable nodes drain during debugging
+                type: boolean
               enableInjector:
                 description: Flag to control whether the network resource injector
                   webhook shall be deployed


### PR DESCRIPTION
SR-IOV Operator drains nodes before applying any configuration on the node NIC. this usually takes some time since it needs to evict the pods on that node. 
This PR adds a new DisableDrain flag in Operator Config CRD to allow disabling of drain process when applying a new policy which in turn saves the waiting time.