### PR TITLE
Bump CRD version to v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+CRD_OPTIONS ?= "crd:crdVersions={v1},trivialVersions=true"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovibnetworks.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovibnetworks.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,59 +15,58 @@ spec:
     plural: sriovibnetworks
     singular: sriovibnetwork
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: SriovIBNetwork is the Schema for the sriovibnetworks API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: SriovIBNetworkSpec defines the desired state of SriovIBNetwork
-          properties:
-            capabilities:
-              description: 'Capabilities to be configured for this network. Capabilities
-                supported: (infinibandGUID), e.g. ''{"infinibandGUID": true}'''
-              type: string
-            ipam:
-              description: IPAM configuration to be used for this network.
-              type: string
-            linkState:
-              description: VF link state (enable|disable|auto)
-              enum:
-              - auto
-              - enable
-              - disable
-              type: string
-            networkNamespace:
-              description: Namespace of the NetworkAttachmentDefinition custom resource
-              type: string
-            resourceName:
-              description: SRIOV Network device plugin endpoint resource name
-              type: string
-          required:
-          - resourceName
-          type: object
-        status:
-          description: SriovIBNetworkStatus defines the observed state of SriovIBNetwork
-          type: object
-      type: object
-  version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovIBNetwork is the Schema for the sriovibnetworks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovIBNetworkSpec defines the desired state of SriovIBNetwork
+            properties:
+              capabilities:
+                description: 'Capabilities to be configured for this network. Capabilities
+                  supported: (infinibandGUID), e.g. ''{"infinibandGUID": true}'''
+                type: string
+              ipam:
+                description: IPAM configuration to be used for this network.
+                type: string
+              linkState:
+                description: VF link state (enable|disable|auto)
+                enum:
+                - auto
+                - enable
+                - disable
+                type: string
+              networkNamespace:
+                description: Namespace of the NetworkAttachmentDefinition custom resource
+                type: string
+              resourceName:
+                description: SRIOV Network device plugin endpoint resource name
+                type: string
+            required:
+            - resourceName
+            type: object
+          status:
+            description: SriovIBNetworkStatus defines the observed state of SriovIBNetwork
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,106 +15,106 @@ spec:
     plural: sriovnetworknodepolicies
     singular: sriovnetworknodepolicy
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: SriovNetworkNodePolicy is the Schema for the sriovnetworknodepolicies
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: SriovNetworkNodePolicySpec defines the desired state of SriovNetworkNodePolicy
-          properties:
-            deviceType:
-              description: The driver type for configured VFs. Allowed value "netdevice",
-                "vfio-pci". Defaults to netdevice.
-              enum:
-              - netdevice
-              - vfio-pci
-              type: string
-            isRdma:
-              description: RDMA mode. Defaults to false.
-              type: boolean
-            linkType:
-              description: NIC Link Type. Allowed value "eth", "ETH", "ib", and "IB".
-              enum:
-              - eth
-              - ETH
-              - ib
-              - IB
-              type: string
-            mtu:
-              description: MTU of VF
-              minimum: 1
-              type: integer
-            nicSelector:
-              description: NicSelector selects the NICs to be configured
-              properties:
-                deviceID:
-                  description: The device hex code of SR-IoV device. Allowed value
-                    "158b", "1015", "1017".
-                  type: string
-                pfNames:
-                  description: Name of SR-IoV PF.
-                  items:
-                    type: string
-                  type: array
-                rootDevices:
-                  description: PCI address of SR-IoV PF.
-                  items:
-                    type: string
-                  type: array
-                vendor:
-                  description: The vendor hex code of SR-IoV device. Allowed value
-                    "8086", "15b3".
-                  type: string
-              type: object
-            nodeSelector:
-              additionalProperties:
-                type: string
-              description: NodeSelector selects the nodes to be configured
-              type: object
-            numVfs:
-              description: Number of VFs for each PF
-              minimum: 0
-              type: integer
-            priority:
-              description: Priority of the policy, higher priority policies can override
-                lower ones.
-              maximum: 99
-              minimum: 0
-              type: integer
-            resourceName:
-              description: SRIOV Network device plugin endpoint resource name
-              type: string
-          required:
-          - nicSelector
-          - nodeSelector
-          - numVfs
-          - resourceName
-          type: object
-        status:
-          description: SriovNetworkNodePolicyStatus defines the observed state of
-            SriovNetworkNodePolicy
-          type: object
-      type: object
-  version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovNetworkNodePolicy is the Schema for the sriovnetworknodepolicies
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovNetworkNodePolicySpec defines the desired state of SriovNetworkNodePolicy
+            properties:
+              deviceType:
+                description: The driver type for configured VFs. Allowed value "netdevice",
+                  "vfio-pci". Defaults to netdevice.
+                enum:
+                - netdevice
+                - vfio-pci
+                type: string
+              isRdma:
+                description: RDMA mode. Defaults to false.
+                type: boolean
+              linkType:
+                description: NIC Link Type. Allowed value "eth", "ETH", "ib", and
+                  "IB".
+                enum:
+                - eth
+                - ETH
+                - ib
+                - IB
+                type: string
+              mtu:
+                description: MTU of VF
+                minimum: 1
+                type: integer
+              nicSelector:
+                description: NicSelector selects the NICs to be configured
+                properties:
+                  deviceID:
+                    description: The device hex code of SR-IoV device. Allowed value
+                      "158b", "1015", "1017".
+                    type: string
+                  pfNames:
+                    description: Name of SR-IoV PF.
+                    items:
+                      type: string
+                    type: array
+                  rootDevices:
+                    description: PCI address of SR-IoV PF.
+                    items:
+                      type: string
+                    type: array
+                  vendor:
+                    description: The vendor hex code of SR-IoV device. Allowed value
+                      "8086", "15b3".
+                    type: string
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector selects the nodes to be configured
+                type: object
+              numVfs:
+                description: Number of VFs for each PF
+                minimum: 0
+                type: integer
+              priority:
+                description: Priority of the policy, higher priority policies can
+                  override lower ones.
+                maximum: 99
+                minimum: 0
+                type: integer
+              resourceName:
+                description: SRIOV Network device plugin endpoint resource name
+                type: string
+            required:
+            - nicSelector
+            - nodeSelector
+            - numVfs
+            - resourceName
+            type: object
+          status:
+            description: SriovNetworkNodePolicyStatus defines the observed state of
+              SriovNetworkNodePolicy
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,132 +15,132 @@ spec:
     plural: sriovnetworknodestates
     singular: sriovnetworknodestate
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: SriovNetworkNodeState is the Schema for the sriovnetworknodestates
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: SriovNetworkNodeStateSpec defines the desired state of SriovNetworkNodeState
-          properties:
-            dpConfigVersion:
-              type: string
-            interfaces:
-              items:
-                properties:
-                  linkType:
-                    type: string
-                  mtu:
-                    type: integer
-                  name:
-                    type: string
-                  numVfs:
-                    type: integer
-                  pciAddress:
-                    type: string
-                  vfGroups:
-                    items:
-                      properties:
-                        deviceType:
-                          type: string
-                        policyName:
-                          type: string
-                        resourceName:
-                          type: string
-                        vfRange:
-                          type: string
-                      type: object
-                    type: array
-                required:
-                - pciAddress
-                type: object
-              type: array
-          type: object
-        status:
-          description: SriovNetworkNodeStateStatus defines the observed state of SriovNetworkNodeState
-          properties:
-            interfaces:
-              items:
-                properties:
-                  Vfs:
-                    items:
-                      properties:
-                        Vlan:
-                          type: integer
-                        assigned:
-                          type: string
-                        deviceID:
-                          type: string
-                        driver:
-                          type: string
-                        mac:
-                          type: string
-                        mtu:
-                          type: integer
-                        name:
-                          type: string
-                        pciAddress:
-                          type: string
-                        vendor:
-                          type: string
-                        vfID:
-                          type: integer
-                      required:
-                      - pciAddress
-                      - vfID
-                      type: object
-                    type: array
-                  deviceID:
-                    type: string
-                  driver:
-                    type: string
-                  linkSpeed:
-                    type: string
-                  linkType:
-                    type: string
-                  mac:
-                    type: string
-                  mtu:
-                    type: integer
-                  name:
-                    type: string
-                  numVfs:
-                    type: integer
-                  pciAddress:
-                    type: string
-                  totalvfs:
-                    type: integer
-                  vendor:
-                    type: string
-                required:
-                - pciAddress
-                type: object
-              type: array
-            lastSyncError:
-              type: string
-            syncStatus:
-              type: string
-          type: object
-      type: object
-  version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovNetworkNodeState is the Schema for the sriovnetworknodestates
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovNetworkNodeStateSpec defines the desired state of SriovNetworkNodeState
+            properties:
+              dpConfigVersion:
+                type: string
+              interfaces:
+                items:
+                  properties:
+                    linkType:
+                      type: string
+                    mtu:
+                      type: integer
+                    name:
+                      type: string
+                    numVfs:
+                      type: integer
+                    pciAddress:
+                      type: string
+                    vfGroups:
+                      items:
+                        properties:
+                          deviceType:
+                            type: string
+                          policyName:
+                            type: string
+                          resourceName:
+                            type: string
+                          vfRange:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - pciAddress
+                  type: object
+                type: array
+            type: object
+          status:
+            description: SriovNetworkNodeStateStatus defines the observed state of
+              SriovNetworkNodeState
+            properties:
+              interfaces:
+                items:
+                  properties:
+                    Vfs:
+                      items:
+                        properties:
+                          Vlan:
+                            type: integer
+                          assigned:
+                            type: string
+                          deviceID:
+                            type: string
+                          driver:
+                            type: string
+                          mac:
+                            type: string
+                          mtu:
+                            type: integer
+                          name:
+                            type: string
+                          pciAddress:
+                            type: string
+                          vendor:
+                            type: string
+                          vfID:
+                            type: integer
+                        required:
+                        - pciAddress
+                        - vfID
+                        type: object
+                      type: array
+                    deviceID:
+                      type: string
+                    driver:
+                      type: string
+                    linkSpeed:
+                      type: string
+                    linkType:
+                      type: string
+                    mac:
+                      type: string
+                    mtu:
+                      type: integer
+                    name:
+                      type: string
+                    numVfs:
+                      type: integer
+                    pciAddress:
+                      type: string
+                    totalvfs:
+                      type: integer
+                    vendor:
+                      type: string
+                  required:
+                  - pciAddress
+                  type: object
+                type: array
+              lastSyncError:
+                type: string
+              syncStatus:
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworks.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworks.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,91 +15,90 @@ spec:
     plural: sriovnetworks
     singular: sriovnetwork
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: SriovNetwork is the Schema for the sriovnetworks API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: SriovNetworkSpec defines the desired state of SriovNetwork
-          properties:
-            capabilities:
-              description: 'Capabilities to be configured for this network. Capabilities
-                supported: (mac|ips), e.g. ''{"mac": true}'''
-              type: string
-            ipam:
-              description: IPAM configuration to be used for this network.
-              type: string
-            linkState:
-              description: VF link state (enable|disable|auto)
-              enum:
-              - auto
-              - enable
-              - disable
-              type: string
-            maxTxRate:
-              description: Maximum tx rate, in Mbps, for the VF. Defaults to 0 (no
-                rate limiting)
-              minimum: 0
-              type: integer
-            minTxRate:
-              description: Minimum tx rate, in Mbps, for the VF. Defaults to 0 (no
-                rate limiting). min_tx_rate should be <= max_tx_rate.
-              minimum: 0
-              type: integer
-            networkNamespace:
-              description: Namespace of the NetworkAttachmentDefinition custom resource
-              type: string
-            resourceName:
-              description: SRIOV Network device plugin endpoint resource name
-              type: string
-            spoofChk:
-              description: VF spoof check, (on|off)
-              enum:
-              - "on"
-              - "off"
-              type: string
-            trust:
-              description: VF trust mode (on|off)
-              enum:
-              - "on"
-              - "off"
-              type: string
-            vlan:
-              description: VLAN ID to assign for the VF. Defaults to 0.
-              maximum: 4096
-              minimum: 0
-              type: integer
-            vlanQoS:
-              description: VLAN QoS ID to assign for the VF. Defaults to 0.
-              maximum: 7
-              minimum: 0
-              type: integer
-          required:
-          - resourceName
-          type: object
-        status:
-          description: SriovNetworkStatus defines the observed state of SriovNetwork
-          type: object
-      type: object
-  version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovNetwork is the Schema for the sriovnetworks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovNetworkSpec defines the desired state of SriovNetwork
+            properties:
+              capabilities:
+                description: 'Capabilities to be configured for this network. Capabilities
+                  supported: (mac|ips), e.g. ''{"mac": true}'''
+                type: string
+              ipam:
+                description: IPAM configuration to be used for this network.
+                type: string
+              linkState:
+                description: VF link state (enable|disable|auto)
+                enum:
+                - auto
+                - enable
+                - disable
+                type: string
+              maxTxRate:
+                description: Maximum tx rate, in Mbps, for the VF. Defaults to 0 (no
+                  rate limiting)
+                minimum: 0
+                type: integer
+              minTxRate:
+                description: Minimum tx rate, in Mbps, for the VF. Defaults to 0 (no
+                  rate limiting). min_tx_rate should be <= max_tx_rate.
+                minimum: 0
+                type: integer
+              networkNamespace:
+                description: Namespace of the NetworkAttachmentDefinition custom resource
+                type: string
+              resourceName:
+                description: SRIOV Network device plugin endpoint resource name
+                type: string
+              spoofChk:
+                description: VF spoof check, (on|off)
+                enum:
+                - "on"
+                - "off"
+                type: string
+              trust:
+                description: VF trust mode (on|off)
+                enum:
+                - "on"
+                - "off"
+                type: string
+              vlan:
+                description: VLAN ID to assign for the VF. Defaults to 0.
+                maximum: 4096
+                minimum: 0
+                type: integer
+              vlanQoS:
+                description: VLAN QoS ID to assign for the VF. Defaults to 0.
+                maximum: 7
+                minimum: 0
+                type: integer
+            required:
+            - resourceName
+            type: object
+          status:
+            description: SriovNetworkStatus defines the observed state of SriovNetwork
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovoperatorconfigs.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovoperatorconfigs.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,67 +15,66 @@ spec:
     plural: sriovoperatorconfigs
     singular: sriovoperatorconfig
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: SriovOperatorConfig is the Schema for the sriovoperatorconfigs
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: SriovOperatorConfigSpec defines the desired state of SriovOperatorConfig
-          properties:
-            configDaemonNodeSelector:
-              additionalProperties:
-                type: string
-              description: NodeSelector selects the nodes to be configured
-              type: object
-            enableInjector:
-              description: Flag to control whether the network resource injector webhook
-                shall be deployed
-              type: boolean
-            enableOperatorWebhook:
-              description: Flag to control whether the operator admission controller
-                webhook shall be deployed
-              type: boolean
-            logLevel:
-              description: Flag to control the log verbose level of the operator.
-                Set to '0' to show only the basic logs. And set to '2' to show all
-                the available logs.
-              maximum: 2
-              minimum: 0
-              type: integer
-          type: object
-        status:
-          description: SriovOperatorConfigStatus defines the observed state of SriovOperatorConfig
-          properties:
-            injector:
-              description: Show the runtime status of the network resource injector
-                webhook
-              type: string
-            operatorWebhook:
-              description: Show the runtime status of the operator admission controller
-                webhook
-              type: string
-          type: object
-      type: object
-  version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovOperatorConfig is the Schema for the sriovoperatorconfigs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovOperatorConfigSpec defines the desired state of SriovOperatorConfig
+            properties:
+              configDaemonNodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector selects the nodes to be configured
+                type: object
+              enableInjector:
+                description: Flag to control whether the network resource injector
+                  webhook shall be deployed
+                type: boolean
+              enableOperatorWebhook:
+                description: Flag to control whether the operator admission controller
+                  webhook shall be deployed
+                type: boolean
+              logLevel:
+                description: Flag to control the log verbose level of the operator.
+                  Set to '0' to show only the basic logs. And set to '2' to show all
+                  the available logs.
+                maximum: 2
+                minimum: 0
+                type: integer
+            type: object
+          status:
+            description: SriovOperatorConfigStatus defines the observed state of SriovOperatorConfig
+            properties:
+              injector:
+                description: Show the runtime status of the network resource injector
+                  webhook
+                type: string
+              operatorWebhook:
+                description: Show the runtime status of the operator admission controller
+                  webhook
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/manifests/4.7/sriov-network-operator-sriovibnetworks_crd.yaml
+++ b/manifests/4.7/sriov-network-operator-sriovibnetworks_crd.yaml
@@ -1,6 +1,11 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
   name: sriovibnetworks.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -62,3 +67,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/manifests/4.7/sriov-network-operator-sriovnetwork.crd.yaml
+++ b/manifests/4.7/sriov-network-operator-sriovnetwork.crd.yaml
@@ -1,6 +1,11 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
   name: sriovnetworks.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -11,86 +16,92 @@ spec:
     singular: sriovnetwork
   scope: Namespaced
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: SriovNetwork is the Schema for the sriovnetworks API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovNetwork is the Schema for the sriovnetworks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: SriovNetworkSpec defines the desired state of SriovNetwork
-              properties:
-                capabilities:
-                  description: 'Capabilities to be configured for this network. Capabilities
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovNetworkSpec defines the desired state of SriovNetwork
+            properties:
+              capabilities:
+                description: 'Capabilities to be configured for this network. Capabilities
                   supported: (mac|ips), e.g. ''{"mac": true}'''
-                  type: string
-                ipam:
-                  description: IPAM configuration to be used for this network.
-                  type: string
-                linkState:
-                  description: VF link state (enable|disable|auto)
-                  enum:
-                    - auto
-                    - enable
-                    - disable
-                  type: string
-                maxTxRate:
-                  description: Maximum tx rate, in Mbps, for the VF. Defaults to 0 (no
-                    rate limiting)
-                  minimum: 0
-                  type: integer
-                minTxRate:
-                  description: Minimum tx rate, in Mbps, for the VF. Defaults to 0 (no
-                    rate limiting). min_tx_rate should be <= max_tx_rate.
-                  minimum: 0
-                  type: integer
-                networkNamespace:
-                  description: Namespace of the NetworkAttachmentDefinition custom resource
-                  type: string
-                resourceName:
-                  description: SRIOV Network device plugin endpoint resource name
-                  type: string
-                spoofChk:
-                  description: VF spoof check, (on|off)
-                  enum:
-                    - "on"
-                    - "off"
-                  type: string
-                trust:
-                  description: VF trust mode (on|off)
-                  enum:
-                    - "on"
-                    - "off"
-                  type: string
-                vlan:
-                  description: VLAN ID to assign for the VF. Defaults to 0.
-                  maximum: 4096
-                  minimum: 0
-                  type: integer
-                vlanQoS:
-                  description: VLAN QoS ID to assign for the VF. Defaults to 0.
-                  maximum: 7
-                  minimum: 0
-                  type: integer
-              required:
-                - resourceName
-              type: object
-            status:
-              description: SriovNetworkStatus defines the observed state of SriovNetwork
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: string
+              ipam:
+                description: IPAM configuration to be used for this network.
+                type: string
+              linkState:
+                description: VF link state (enable|disable|auto)
+                enum:
+                - auto
+                - enable
+                - disable
+                type: string
+              maxTxRate:
+                description: Maximum tx rate, in Mbps, for the VF. Defaults to 0 (no
+                  rate limiting)
+                minimum: 0
+                type: integer
+              minTxRate:
+                description: Minimum tx rate, in Mbps, for the VF. Defaults to 0 (no
+                  rate limiting). min_tx_rate should be <= max_tx_rate.
+                minimum: 0
+                type: integer
+              networkNamespace:
+                description: Namespace of the NetworkAttachmentDefinition custom resource
+                type: string
+              resourceName:
+                description: SRIOV Network device plugin endpoint resource name
+                type: string
+              spoofChk:
+                description: VF spoof check, (on|off)
+                enum:
+                - "on"
+                - "off"
+                type: string
+              trust:
+                description: VF trust mode (on|off)
+                enum:
+                - "on"
+                - "off"
+                type: string
+              vlan:
+                description: VLAN ID to assign for the VF. Defaults to 0.
+                maximum: 4096
+                minimum: 0
+                type: integer
+              vlanQoS:
+                description: VLAN QoS ID to assign for the VF. Defaults to 0.
+                maximum: 7
+                minimum: 0
+                type: integer
+            required:
+            - resourceName
+            type: object
+          status:
+            description: SriovNetworkStatus defines the observed state of SriovNetwork
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/manifests/4.7/sriov-network-operator-sriovnetworknodepolicy.crd.yaml
+++ b/manifests/4.7/sriov-network-operator-sriovnetworknodepolicy.crd.yaml
@@ -1,6 +1,11 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
   name: sriovnetworknodepolicies.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -11,102 +16,108 @@ spec:
     singular: sriovnetworknodepolicy
   scope: Namespaced
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: SriovNetworkNodePolicy is the Schema for the sriovnetworknodepolicies
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovNetworkNodePolicy is the Schema for the sriovnetworknodepolicies
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: SriovNetworkNodePolicySpec defines the desired state of SriovNetworkNodePolicy
-              properties:
-                deviceType:
-                  description: The driver type for configured VFs. Allowed value "netdevice",
-                    "vfio-pci". Defaults to netdevice.
-                  enum:
-                    - netdevice
-                    - vfio-pci
-                  type: string
-                isRdma:
-                  description: RDMA mode. Defaults to false.
-                  type: boolean
-                linkType:
-                  description: NIC Link Type. Allowed value "eth", "ETH", "ib", and
-                    "IB".
-                  enum:
-                    - eth
-                    - ETH
-                    - ib
-                    - IB
-                  type: string
-                mtu:
-                  description: MTU of VF
-                  minimum: 1
-                  type: integer
-                nicSelector:
-                  description: NicSelector selects the NICs to be configured
-                  properties:
-                    deviceID:
-                      description: The device hex code of SR-IoV device. Allowed value
-                        "158b", "1015", "1017".
-                      type: string
-                    pfNames:
-                      description: Name of SR-IoV PF.
-                      items:
-                        type: string
-                      type: array
-                    rootDevices:
-                      description: PCI address of SR-IoV PF.
-                      items:
-                        type: string
-                      type: array
-                    vendor:
-                      description: The vendor hex code of SR-IoV device. Allowed value
-                        "8086", "15b3".
-                      type: string
-                  type: object
-                nodeSelector:
-                  additionalProperties:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovNetworkNodePolicySpec defines the desired state of SriovNetworkNodePolicy
+            properties:
+              deviceType:
+                description: The driver type for configured VFs. Allowed value "netdevice",
+                  "vfio-pci". Defaults to netdevice.
+                enum:
+                - netdevice
+                - vfio-pci
+                type: string
+              isRdma:
+                description: RDMA mode. Defaults to false.
+                type: boolean
+              linkType:
+                description: NIC Link Type. Allowed value "eth", "ETH", "ib", and
+                  "IB".
+                enum:
+                - eth
+                - ETH
+                - ib
+                - IB
+                type: string
+              mtu:
+                description: MTU of VF
+                minimum: 1
+                type: integer
+              nicSelector:
+                description: NicSelector selects the NICs to be configured
+                properties:
+                  deviceID:
+                    description: The device hex code of SR-IoV device. Allowed value
+                      "158b", "1015", "1017".
                     type: string
-                  description: NodeSelector selects the nodes to be configured
-                  type: object
-                numVfs:
-                  description: Number of VFs for each PF
-                  minimum: 0
-                  type: integer
-                priority:
-                  description: Priority of the policy, higher priority policies can
-                    override lower ones.
-                  maximum: 99
-                  minimum: 0
-                  type: integer
-                resourceName:
-                  description: SRIOV Network device plugin endpoint resource name
+                  pfNames:
+                    description: Name of SR-IoV PF.
+                    items:
+                      type: string
+                    type: array
+                  rootDevices:
+                    description: PCI address of SR-IoV PF.
+                    items:
+                      type: string
+                    type: array
+                  vendor:
+                    description: The vendor hex code of SR-IoV device. Allowed value
+                      "8086", "15b3".
+                    type: string
+                type: object
+              nodeSelector:
+                additionalProperties:
                   type: string
-              required:
-                - nicSelector
-                - nodeSelector
-                - numVfs
-                - resourceName
-              type: object
-            status:
-              description: SriovNetworkNodePolicyStatus defines the observed state of
-                SriovNetworkNodePolicy
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                description: NodeSelector selects the nodes to be configured
+                type: object
+              numVfs:
+                description: Number of VFs for each PF
+                minimum: 0
+                type: integer
+              priority:
+                description: Priority of the policy, higher priority policies can
+                  override lower ones.
+                maximum: 99
+                minimum: 0
+                type: integer
+              resourceName:
+                description: SRIOV Network device plugin endpoint resource name
+                type: string
+            required:
+            - nicSelector
+            - nodeSelector
+            - numVfs
+            - resourceName
+            type: object
+          status:
+            description: SriovNetworkNodePolicyStatus defines the observed state of
+              SriovNetworkNodePolicy
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/manifests/4.7/sriov-network-operator-sriovnetworknodestate.crd.yaml
+++ b/manifests/4.7/sriov-network-operator-sriovnetworknodestate.crd.yaml
@@ -1,6 +1,11 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
   name: sriovnetworknodestates.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -11,128 +16,134 @@ spec:
     singular: sriovnetworknodestate
   scope: Namespaced
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: SriovNetworkNodeState is the Schema for the sriovnetworknodestates
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovNetworkNodeState is the Schema for the sriovnetworknodestates
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: SriovNetworkNodeStateSpec defines the desired state of SriovNetworkNodeState
-              properties:
-                dpConfigVersion:
-                  type: string
-                interfaces:
-                  items:
-                    properties:
-                      linkType:
-                        type: string
-                      mtu:
-                        type: integer
-                      name:
-                        type: string
-                      numVfs:
-                        type: integer
-                      pciAddress:
-                        type: string
-                      vfGroups:
-                        items:
-                          properties:
-                            deviceType:
-                              type: string
-                            policyName:
-                              type: string
-                            resourceName:
-                              type: string
-                            vfRange:
-                              type: string
-                          type: object
-                        type: array
-                    required:
-                      - pciAddress
-                    type: object
-                  type: array
-              type: object
-            status:
-              description: SriovNetworkNodeStateStatus defines the observed state of
-                SriovNetworkNodeState
-              properties:
-                interfaces:
-                  items:
-                    properties:
-                      Vfs:
-                        items:
-                          properties:
-                            Vlan:
-                              type: integer
-                            assigned:
-                              type: string
-                            deviceID:
-                              type: string
-                            driver:
-                              type: string
-                            mac:
-                              type: string
-                            mtu:
-                              type: integer
-                            name:
-                              type: string
-                            pciAddress:
-                              type: string
-                            vendor:
-                              type: string
-                            vfID:
-                              type: integer
-                          required:
-                            - pciAddress
-                            - vfID
-                          type: object
-                        type: array
-                      deviceID:
-                        type: string
-                      driver:
-                        type: string
-                      linkSpeed:
-                        type: string
-                      linkType:
-                        type: string
-                      mac:
-                        type: string
-                      mtu:
-                        type: integer
-                      name:
-                        type: string
-                      numVfs:
-                        type: integer
-                      pciAddress:
-                        type: string
-                      totalvfs:
-                        type: integer
-                      vendor:
-                        type: string
-                    required:
-                      - pciAddress
-                    type: object
-                  type: array
-                lastSyncError:
-                  type: string
-                syncStatus:
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovNetworkNodeStateSpec defines the desired state of SriovNetworkNodeState
+            properties:
+              dpConfigVersion:
+                type: string
+              interfaces:
+                items:
+                  properties:
+                    linkType:
+                      type: string
+                    mtu:
+                      type: integer
+                    name:
+                      type: string
+                    numVfs:
+                      type: integer
+                    pciAddress:
+                      type: string
+                    vfGroups:
+                      items:
+                        properties:
+                          deviceType:
+                            type: string
+                          policyName:
+                            type: string
+                          resourceName:
+                            type: string
+                          vfRange:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - pciAddress
+                  type: object
+                type: array
+            type: object
+          status:
+            description: SriovNetworkNodeStateStatus defines the observed state of
+              SriovNetworkNodeState
+            properties:
+              interfaces:
+                items:
+                  properties:
+                    Vfs:
+                      items:
+                        properties:
+                          Vlan:
+                            type: integer
+                          assigned:
+                            type: string
+                          deviceID:
+                            type: string
+                          driver:
+                            type: string
+                          mac:
+                            type: string
+                          mtu:
+                            type: integer
+                          name:
+                            type: string
+                          pciAddress:
+                            type: string
+                          vendor:
+                            type: string
+                          vfID:
+                            type: integer
+                        required:
+                        - pciAddress
+                        - vfID
+                        type: object
+                      type: array
+                    deviceID:
+                      type: string
+                    driver:
+                      type: string
+                    linkSpeed:
+                      type: string
+                    linkType:
+                      type: string
+                    mac:
+                      type: string
+                    mtu:
+                      type: integer
+                    name:
+                      type: string
+                    numVfs:
+                      type: integer
+                    pciAddress:
+                      type: string
+                    totalvfs:
+                      type: integer
+                    vendor:
+                      type: string
+                  required:
+                  - pciAddress
+                  type: object
+                type: array
+              lastSyncError:
+                type: string
+              syncStatus:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/manifests/4.7/sriov-network-operator-sriovoperatorconfig.crd.yaml
+++ b/manifests/4.7/sriov-network-operator-sriovoperatorconfig.crd.yaml
@@ -1,6 +1,11 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
   name: sriovoperatorconfigs.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -11,62 +16,68 @@ spec:
     singular: sriovoperatorconfig
   scope: Namespaced
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: SriovOperatorConfig is the Schema for the sriovoperatorconfigs
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovOperatorConfig is the Schema for the sriovoperatorconfigs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: SriovOperatorConfigSpec defines the desired state of SriovOperatorConfig
-              properties:
-                configDaemonNodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: NodeSelector selects the nodes to be configured
-                  type: object
-                enableInjector:
-                  description: Flag to control whether the network resource injector
-                    webhook shall be deployed
-                  type: boolean
-                enableOperatorWebhook:
-                  description: Flag to control whether the operator admission controller
-                    webhook shall be deployed
-                  type: boolean
-                logLevel:
-                  description: Flag to control the log verbose level of the operator.
-                    Set to '0' to show only the basic logs. And set to '2' to show all
-                    the available logs.
-                  maximum: 2
-                  minimum: 0
-                  type: integer
-              type: object
-            status:
-              description: SriovOperatorConfigStatus defines the observed state of SriovOperatorConfig
-              properties:
-                injector:
-                  description: Show the runtime status of the network resource injector
-                    webhook
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovOperatorConfigSpec defines the desired state of SriovOperatorConfig
+            properties:
+              configDaemonNodeSelector:
+                additionalProperties:
                   type: string
-                operatorWebhook:
-                  description: Show the runtime status of the operator admission controller
-                    webhook
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                description: NodeSelector selects the nodes to be configured
+                type: object
+              enableInjector:
+                description: Flag to control whether the network resource injector
+                  webhook shall be deployed
+                type: boolean
+              enableOperatorWebhook:
+                description: Flag to control whether the operator admission controller
+                  webhook shall be deployed
+                type: boolean
+              logLevel:
+                description: Flag to control the log verbose level of the operator.
+                  Set to '0' to show only the basic logs. And set to '2' to show all
+                  the available logs.
+                maximum: 2
+                minimum: 0
+                type: integer
+            type: object
+          status:
+            description: SriovOperatorConfigStatus defines the observed state of SriovOperatorConfig
+            properties:
+              injector:
+                description: Show the runtime status of the network resource injector
+                  webhook
+                type: string
+              operatorWebhook:
+                description: Show the runtime status of the operator admission controller
+                  webhook
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
In operator-sdk 1.0.1, the defaule generated CRD version is v1beta1.
We change it back to v1, as we've been using v1 for a long time.