### PR TITLE
Add support for OpenStack metadata

### DIFF
--- a/api/v1/sriovnetworknodepolicy_types.go
+++ b/api/v1/sriovnetworknodepolicy_types.go
@@ -50,6 +50,8 @@ type SriovNetworkNicSelector struct {
 	RootDevices []string `json:"rootDevices,omitempty"`
 	// Name of SR-IoV PF.
 	PfNames []string `json:"pfNames,omitempty"`
+	// Infrastructure Networking selection filter. Allowed value "openstack/NetworkID:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+	NetFilter string `json:"netFilter,omitempty"`
 }
 
 // SriovNetworkNodePolicyStatus defines the observed state of SriovNetworkNodePolicy

--- a/api/v1/sriovnetworknodestate_types.go
+++ b/api/v1/sriovnetworknodestate_types.go
@@ -40,6 +40,7 @@ type InterfaceExt struct {
 	PciAddress  string            `json:"pciAddress"`
 	Vendor      string            `json:"vendor,omitempty"`
 	DeviceID    string            `json:"deviceID,omitempty"`
+	NetFilter   string            `json:"netFilter,omitempty"`
 	Mtu         int               `json:"mtu,omitempty"`
 	NumVfs      int               `json:"numVfs,omitempty"`
 	LinkSpeed   string            `json:"linkSpeed,omitempty"`

--- a/cmd/sriov-network-config-daemon/start.go
+++ b/cmd/sriov-network-config-daemon/start.go
@@ -13,6 +13,7 @@ import (
 	sriovnetworkv1 "github.com/openshift/sriov-network-operator/api/v1"
 	snclientset "github.com/openshift/sriov-network-operator/pkg/client/clientset/versioned"
 	"github.com/openshift/sriov-network-operator/pkg/daemon"
+	"github.com/openshift/sriov-network-operator/pkg/utils"
 	"github.com/openshift/sriov-network-operator/pkg/version"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,8 +38,8 @@ var (
 	}
 
 	// PlatformMap contains supported platforms for virtual VF
-	platformMap = map[string]daemon.PlatformType{
-		"openstack": daemon.Virtual,
+	platformMap = map[string]utils.PlatformType{
+		"openstack": utils.VirtualOpenStack,
 	}
 )
 
@@ -115,7 +116,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		destdir = "/host/etc"
 	}
 
-	platformType := daemon.Baremetal
+	platformType := utils.Baremetal
 
 	nodeInfo, err := kubeclient.CoreV1().Nodes().Get(context.Background(), startOpts.nodeName, v1.GetOptions{})
 	if err == nil {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -42,27 +42,6 @@ import (
 	"github.com/openshift/sriov-network-operator/pkg/utils"
 )
 
-// PlatformType foo
-type PlatformType int
-
-const (
-	// Baremetal platform
-	Baremetal PlatformType = iota
-	// Virtual platform
-	Virtual
-)
-
-func (e PlatformType) String() string {
-	switch e {
-	case Baremetal:
-		return "Baremetal"
-	case Virtual:
-		return "Virtual"
-	default:
-		return fmt.Sprintf("%d", int(e))
-	}
-}
-
 const (
 	// updateDelay is the baseline speed at which we react to changes.  We don't
 	// need to react in milliseconds as any change would involve rebooting the node.
@@ -84,7 +63,7 @@ type Daemon struct {
 	name      string
 	namespace string
 
-	platform PlatformType
+	platform utils.PlatformType
 
 	client snclientset.Interface
 	// kubeClient allows interaction with Kubernetes, including the node we are running on.
@@ -154,7 +133,7 @@ func New(
 	stopCh <-chan struct{},
 	syncCh <-chan struct{},
 	refreshCh chan<- Message,
-	platformType PlatformType,
+	platformType utils.PlatformType,
 ) *Daemon {
 	return &Daemon{
 		name:       nodeName,
@@ -640,7 +619,7 @@ func (dn *Daemon) restartDevicePluginPod() error {
 func (dn *Daemon) loadVendorPlugins(ns *sriovnetworkv1.SriovNetworkNodeState) error {
 	var pl []string
 
-	if dn.platform == Virtual {
+	if dn.platform == utils.VirtualOpenStack {
 		pl = append(pl, VirtualPlugin)
 	} else {
 		pl = registerPlugins(ns)

--- a/pkg/daemon/writer.go
+++ b/pkg/daemon/writer.go
@@ -40,7 +40,7 @@ func NewNodeStateStatusWriter(c snclientset.Interface, n string, f func()) *Node
 
 // Run reads from the writer channel and sets the interface status. It will
 // return if the stop channel is closed. Intended to be run via a goroutine.
-func (writer *NodeStateStatusWriter) Run(stop <-chan struct{}, refresh <-chan Message, syncCh chan<- struct{}, destDir string, runonce bool, platformType PlatformType) {
+func (writer *NodeStateStatusWriter) Run(stop <-chan struct{}, refresh <-chan Message, syncCh chan<- struct{}, destDir string, runonce bool, platformType utils.PlatformType) {
 	glog.V(0).Infof("Run(): start writer")
 	msg := Message{}
 	if runonce {
@@ -76,13 +76,13 @@ func (writer *NodeStateStatusWriter) Run(stop <-chan struct{}, refresh <-chan Me
 	}
 }
 
-func (writer *NodeStateStatusWriter) pollNicStatus(platformType PlatformType) error {
+func (writer *NodeStateStatusWriter) pollNicStatus(platformType utils.PlatformType) error {
 	glog.V(2).Info("pollNicStatus()")
 	var iface []sriovnetworkv1.InterfaceExt
 	var err error
 
-	if platformType == Virtual {
-		iface, err = utils.DiscoverSriovDevicesVirtual()
+	if platformType == utils.VirtualOpenStack {
+		iface, err = utils.DiscoverSriovDevicesVirtual(platformType)
 	} else {
 		iface, err = utils.DiscoverSriovDevices()
 	}


### PR DESCRIPTION
[Addresses Issue](https://github.com/openshift/sriov-network-operator/issues/399)

When OpenShift is deployed on OpenStack, OpenStack provides additional metadata about networks that can be used by the sriov-network-operator. This metadata specifies which OpenStack networks (UUID) are connected to which interface of the VM. In addition, if Device Role Tagging is used, the metadata can also provide labels that allow the grouping of VF resources.