### PR TITLE
Use the right object when webhook delete operation

### DIFF
--- a/bindata/manifests/operator-webhook/003-webhook.yaml
+++ b/bindata/manifests/operator-webhook/003-webhook.yaml
@@ -33,7 +33,7 @@ webhooks:
         namespace: {{.Namespace}}
         path: "/validating-custom-resource"
     rules:
-      - operations: [ "CREATE", "UPDATE" ]
+      - operations: [ "CREATE", "UPDATE", "DELETE" ]
         apiGroups: ["sriovnetwork.openshift.io"]
         apiVersions: ["v1"]
         resources: ["sriovnetworknodepolicies"]

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -42,6 +42,12 @@ func ValidateCustomResource(ar v1beta1.AdmissionReview) *v1beta1.AdmissionRespon
 	reviewResponse := v1beta1.AdmissionResponse{}
 	reviewResponse.Allowed = true
 
+	if ar.Request.Operation == "DELETE" {
+		raw = ar.Request.OldObject.Raw
+	} else {
+		raw = ar.Request.Object.Raw
+	}
+
 	switch ar.Request.Kind.Kind {
 	case "SriovNetworkNodePolicy":
 		policy := sriovnetworkv1.SriovNetworkNodePolicy{}


### PR DESCRIPTION
Currently operator-webhook denies every delete operation with:
denied the request: unexpected end of JSON input