### PR TITLE
Deploy AdmissionController when ENABLE_ADMISSION_CONTROLLER is true

### DIFF
--- a/main.go
+++ b/main.go
@@ -185,10 +185,11 @@ func createDefaultOperatorConfig(cfg *rest.Config) error {
 	if err != nil {
 		return fmt.Errorf("Couldn't create client: %v", err)
 	}
+	enableAdmissionController := os.Getenv("ENABLE_ADMISSION_CONTROLLER") == "true"
 	config := &sriovnetworkv1.SriovOperatorConfig{
 		Spec: sriovnetworkv1.SriovOperatorConfigSpec{
-			EnableInjector:           func() *bool { b := true; return &b }(),
-			EnableOperatorWebhook:    func() *bool { b := true; return &b }(),
+			EnableInjector:           func() *bool { b := enableAdmissionController; return &b }(),
+			EnableOperatorWebhook:    func() *bool { b := enableAdmissionController; return &b }(),
 			ConfigDaemonNodeSelector: map[string]string{},
 			LogLevel:                 2,
 		},


### PR DESCRIPTION
Currently webhook and injector are deployed by default ignoring the environment variable ENABLE_ADMISSION_CONTROLLER which cause the operator to broke on vanilla kubernetes

This commit restrict deploying  webhook and injector when ENABLE_ADMISSION_CONTROLLER is true

Fixes #401 