### PR TITLE
Bug 1898580: fix the sriov daemon selector assignement.

### DIFF
--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -464,27 +464,7 @@ func (r *SriovNetworkNodePolicyReconciler) syncDaemonSet(cr *sriovnetworkv1.Srio
 }
 
 func setDsNodeAffinity(pl *sriovnetworkv1.SriovNetworkNodePolicyList, ds *appsv1.DaemonSet) error {
-	terms := []corev1.NodeSelectorTerm{}
-	for _, p := range pl.Items {
-		nodeSelector := corev1.NodeSelectorTerm{}
-		if len(p.Spec.NodeSelector) == 0 {
-			continue
-		}
-		for k, v := range p.Spec.NodeSelector {
-			expressions := []corev1.NodeSelectorRequirement{}
-			exp := corev1.NodeSelectorRequirement{
-				Operator: corev1.NodeSelectorOpIn,
-				Key:      k,
-				Values:   []string{v},
-			}
-			expressions = append(expressions, exp)
-			nodeSelector = corev1.NodeSelectorTerm{
-				MatchExpressions: expressions,
-			}
-		}
-		terms = append(terms, nodeSelector)
-	}
-
+	terms := nodeSelectorTermsForPolicyList(pl.Items)
 	if len(terms) > 0 {
 		ds.Spec.Template.Spec.Affinity = &corev1.Affinity{
 			NodeAffinity: &corev1.NodeAffinity{
@@ -495,6 +475,36 @@ func setDsNodeAffinity(pl *sriovnetworkv1.SriovNetworkNodePolicyList, ds *appsv1
 		}
 	}
 	return nil
+}
+
+func nodeSelectorTermsForPolicyList(policies []sriovnetworkv1.SriovNetworkNodePolicy) []corev1.NodeSelectorTerm {
+	terms := []corev1.NodeSelectorTerm{}
+	for _, p := range policies {
+		nodeSelector := corev1.NodeSelectorTerm{}
+		if len(p.Spec.NodeSelector) == 0 {
+			continue
+		}
+		expressions := []corev1.NodeSelectorRequirement{}
+		for k, v := range p.Spec.NodeSelector {
+			exp := corev1.NodeSelectorRequirement{
+				Operator: corev1.NodeSelectorOpIn,
+				Key:      k,
+				Values:   []string{v},
+			}
+			expressions = append(expressions, exp)
+		}
+		// sorting is needed to keep the daemon spec stable.
+		// the items are popped in a random order from the map
+		sort.Slice(expressions, func(i, j int) bool {
+			return expressions[i].Key < expressions[j].Key
+		})
+		nodeSelector = corev1.NodeSelectorTerm{
+			MatchExpressions: expressions,
+		}
+		terms = append(terms, nodeSelector)
+	}
+
+	return terms
 }
 
 // renderDsForCR returns a busybox pod with the same name/namespace as the cr

--- a/controllers/sriovnetworknodepolicy_controller_test.go
+++ b/controllers/sriovnetworknodepolicy_controller_test.go
@@ -1,0 +1,124 @@
+package controllers
+
+import (
+	"testing"
+
+	sriovnetworkv1 "github.com/openshift/sriov-network-operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNodeSelectorMerge(t *testing.T) {
+	table := []struct {
+		tname    string
+		policies []sriovnetworkv1.SriovNetworkNodePolicy
+		expected []corev1.NodeSelectorTerm
+	}{
+		{
+			tname: "testoneselector",
+			policies: []sriovnetworkv1.SriovNetworkNodePolicy{
+				{
+					Spec: sriovnetworkv1.SriovNetworkNodePolicySpec{
+						NodeSelector: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+				{
+					Spec: sriovnetworkv1.SriovNetworkNodePolicySpec{
+						NodeSelector: map[string]string{
+							"bb": "cc",
+						},
+					},
+				},
+			},
+			expected: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Key:      "foo",
+							Values:   []string{"bar"},
+						},
+					},
+				},
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Key:      "bb",
+							Values:   []string{"cc"},
+						},
+					},
+				},
+			},
+		},
+		{
+			tname: "testtwoselectors",
+			policies: []sriovnetworkv1.SriovNetworkNodePolicy{
+				{
+					Spec: sriovnetworkv1.SriovNetworkNodePolicySpec{
+						NodeSelector: map[string]string{
+							"foo":  "bar",
+							"foo1": "bar1",
+						},
+					},
+				},
+				{
+					Spec: sriovnetworkv1.SriovNetworkNodePolicySpec{
+						NodeSelector: map[string]string{
+							"bb":  "cc",
+							"bb1": "cc1",
+							"bb2": "cc2",
+						},
+					},
+				},
+			},
+			expected: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Key:      "foo",
+							Values:   []string{"bar"},
+						},
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Key:      "foo1",
+							Values:   []string{"bar1"},
+						},
+					},
+				},
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Key:      "bb",
+							Values:   []string{"cc"},
+						},
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Key:      "bb1",
+							Values:   []string{"cc1"},
+						},
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Key:      "bb2",
+							Values:   []string{"cc2"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range table {
+		t.Run(tc.tname, func(t *testing.T) {
+			selectors := nodeSelectorTermsForPolicyList(tc.policies)
+			if !cmp.Equal(selectors, tc.expected) {
+				t.Error(tc.tname, "Selectors not as expected", cmp.Diff(selectors, tc.expected))
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,9 @@ require (
 	github.com/go-logr/logr v0.2.1
 	github.com/go-logr/zapr v0.2.0 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/google/go-cmp v0.5.0
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/intel/sriov-network-device-plugin v0.0.0-20200924101303-b7f6d3e06797
-
 	github.com/jaypipes/ghw v0.6.1
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v0.0.0-20200626054723-37f83d1996bc
 	github.com/mitchellh/copystructure v1.0.0 // indirect
@@ -22,7 +22,6 @@ require (
 	github.com/onsi/gomega v1.10.1
 	github.com/openshift/client-go v0.0.0-20200320150128-a906f3d8e723
 	github.com/openshift/machine-config-operator v4.2.0-alpha.0.0.20190917115525-033375cbe820+incompatible
-
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0
 	github.com/vishvananda/netlink v1.1.0


### PR DESCRIPTION
The current implementation only assigns the first label found in the policy selector.

This causes two issues: do not use the second label specified by the user, and given the fact that the iteration on a map is executed in a random way, the definition of the daemonset is different every reconciliation loop, causing a restart of the pods under the daemonsets.
