### PR TITLE
Work around udev race condition related to NM_UNMANAGED=1

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -742,7 +742,7 @@ func tryCreateUdevRule() error {
 			return err
 		}
 	}
-	content := fmt.Sprintf("ACTION==\"add|change\", ATTRS{device}==\"%s\", ENV{NM_UNMANAGED}=\"1\"\n", strings.Join(sriovnetworkv1.VfIds, "|"))
+	content := fmt.Sprintf("ACTION==\"add|change|move\", ATTRS{device}==\"%s\", ENV{NM_UNMANAGED}=\"1\"\n", strings.Join(sriovnetworkv1.VfIds, "|"))
 	err = ioutil.WriteFile(filePath, []byte(content), 0666)
 	if err != nil {
 		glog.Errorf("tryCreateUdevRule(): fail to write file: %v", err)


### PR DESCRIPTION
Work around a udev race condition where NM_UNMANAGED=1 
added to a device path after multiple repeated move operations
of a VF from the host namespace to a pod and back.