### PR TITLE
Allow non supported hardware for testing purposes

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -81,3 +81,22 @@ rules:
     - securitycontextconstraints
   verbs:
     - use
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: operator-webhook-sa
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -21,3 +21,15 @@ roleRef:
   kind: Role
   name: sriov-network-config-daemon
   apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: operator-webhook-sa
+subjects:
+- kind: ServiceAccount
+  name: operator-webhook-sa
+roleRef:
+  kind: Role
+  name: operator-webhook-sa
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This patch implements a new field to the SriovOperatorConfig CRD
with name "unsupportedNicIdMap". This setting allows the configuration
of unsupported NIC models, example: [{"X520":"8086 154d 10ed"}