### PR TITLE
Tests: ignore get errors when checking for sriov stable

### DIFF
--- a/test/conformance/tests/sriov_operator.go
+++ b/test/conformance/tests/sriov_operator.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -1723,21 +1722,14 @@ func waitForSRIOVStable() {
 
 	time.Sleep(5 * time.Second)
 
-	eofErrorCount := 0
+	fmt.Println("Waiting for the sriov state to stable")
 	Eventually(func() bool {
-		res, err := cluster.SriovStable(operatorNamespace, clients)
-		// The check for EofError is done to temorarily work around an issue
-		// occuring during tests run. The issue occurs very sporadicly and as such
-		// is difficult to identify. eofErrorCount is introduced to allow us to respond
-		// to real issues.
-		if err == io.ErrUnexpectedEOF {
-			eofErrorCount++
-			Expect(eofErrorCount).To(BeNumerically("<", 2))
-			return false
-		}
-		Expect(err).ToNot(HaveOccurred())
+		// ignoring the error. This can eventually be executed against a single node cluster,
+		// and if a reconfiguration triggers a reboot then the api calls will return an error
+		res, _ := cluster.SriovStable(operatorNamespace, clients)
 		return res
 	}, waitingTime, 1*time.Second).Should(BeTrue())
+	fmt.Println("Sriov state is stable")
 
 	Eventually(func() bool {
 		isClusterReady, err := cluster.IsClusterStable(clients)

--- a/test/util/cluster/cluster.go
+++ b/test/util/cluster/cluster.go
@@ -41,7 +41,7 @@ func DiscoverSriov(clients *testclient.ClientSet, operatorNamespace string) (*En
 	}
 
 	for _, state := range ss {
-		isStable, err := stateStable(state, clients, operatorNamespace)
+		isStable, err := stateStable(state)
 		if err != nil {
 			return nil, err
 		}
@@ -126,7 +126,7 @@ func SriovStable(operatorNamespace string, clients *testclient.ClientSet) (bool,
 		return false, nil
 	}
 	for _, state := range nodeStates.Items {
-		nodeReady, err := stateStable(state, clients, operatorNamespace)
+		nodeReady, err := stateStable(state)
 		if err != nil {
 			return false, err
 		}
@@ -137,7 +137,7 @@ func SriovStable(operatorNamespace string, clients *testclient.ClientSet) (bool,
 	return true, nil
 }
 
-func stateStable(state sriovv1.SriovNetworkNodeState, clients *testclient.ClientSet, operatorNamespace string) (bool, error) {
+func stateStable(state sriovv1.SriovNetworkNodeState) (bool, error) {
 	switch state.Status.SyncStatus {
 	case "Succeeded":
 		return true, nil


### PR DESCRIPTION
When running the tests against a single cluster, configuration changes may trigger reboots. Here we ignore the error, assuming that the cluster will be back within the timeout. Other calls to the api server are done before reaching this stage, so it's safe to assume that running the tests against a wrong cluster will result in an earlier error.