### PR TITLE
Automatically copy generated yaml files to the ./manifests/4.7 dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ IMAGE_BUILD_OPTS?=
 DOCKERFILE?=Dockerfile
 
 CRD_BASES=./config/crd/bases
-MANIFESTS_4.7=./manifests/4.7
 
 export APP_NAME=sriov-network-operator
 APP_REPO=github.com/openshift/$(APP_NAME)
@@ -105,10 +104,16 @@ uninstall: manifests kustomize
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) webhook paths="./..." output:crd:artifacts:config=$(CRD_BASES)
-	cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovibnetworks.yaml 		$(MANIFESTS_4.7)/sriov-network-operator-sriovibnetworks_crd.yaml
-	cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml 	$(MANIFESTS_4.7)/sriov-network-operator-sriovnetworknodepolicy.crd.yaml
-	cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovnetworknodestates.yaml 	$(MANIFESTS_4.7)/sriov-network-operator-sriovnetworknodestate.crd.yaml
-	cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovoperatorconfigs.yaml  	$(MANIFESTS_4.7)/sriov-network-operator-sriovoperatorconfig.crd.yaml
+
+
+sync-manifests-%: manifests
+	@mkdir -p MANIFESTS/$*
+	@cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovibnetworks.yaml		MANIFESTS/$*/sriov-network-operator-sriovibnetworks_crd.yaml
+	@cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml 	MANIFESTS/$*/sriov-network-operator-sriovnetworknodepolicy.crd.yaml
+	@cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovnetworknodestates.yaml 	MANIFESTS/$*/sriov-network-operator-sriovnetworknodestate.crd.yaml
+	@cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovoperatorconfigs.yaml  	MANIFESTS/$*/sriov-network-operator-sriovoperatorconfig.crd.yaml
+	@cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovnetworks.yaml			MANIFESTS/$*/sriov-network-operator-sriovnetwork.crd.yaml
+	@echo "Please manually update the sriov-network-operator.v4.7.0.clusterserviceversion.yaml and image-references files in  MANIFESTS/$* directory"
 
 
 # Run go fmt against code

--- a/Makefile
+++ b/Makefile
@@ -107,13 +107,17 @@ manifests: controller-gen
 
 
 sync-manifests-%: manifests
-	@mkdir -p MANIFESTS/$*
-	@cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovibnetworks.yaml		MANIFESTS/$*/sriov-network-operator-sriovibnetworks_crd.yaml
-	@cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml 	MANIFESTS/$*/sriov-network-operator-sriovnetworknodepolicy.crd.yaml
-	@cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovnetworknodestates.yaml 	MANIFESTS/$*/sriov-network-operator-sriovnetworknodestate.crd.yaml
-	@cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovoperatorconfigs.yaml  	MANIFESTS/$*/sriov-network-operator-sriovoperatorconfig.crd.yaml
-	@cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovnetworks.yaml			MANIFESTS/$*/sriov-network-operator-sriovnetwork.crd.yaml
-	@echo "Please manually update the sriov-network-operator.v4.7.0.clusterserviceversion.yaml and image-references files in  MANIFESTS/$* directory"
+	@mkdir -p manifests/$*
+	sed '2{/---/d}' $(CRD_BASES)/sriovnetwork.openshift.io_sriovibnetworks.yaml | awk 'NF' > manifests/$*/sriov-network-operator-sriovibnetworks_crd.yaml
+	sed '2{/---/d}' $(CRD_BASES)/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml | awk 'NF' > manifests/$*/sriov-network-operator-sriovnetworknodepolicy.crd.yaml
+	sed '2{/---/d}' $(CRD_BASES)/sriovnetwork.openshift.io_sriovnetworknodestates.yaml | awk 'NF' > manifests/$*/sriov-network-operator-sriovnetworknodestate.crd.yaml
+	sed '2{/---/d}' $(CRD_BASES)/sriovnetwork.openshift.io_sriovoperatorconfigs.yaml | awk 'NF' > manifests/$*/sriov-network-operator-sriovoperatorconfig.crd.yaml
+	sed '2{/---/d}' $(CRD_BASES)/sriovnetwork.openshift.io_sriovnetworks.yaml | awk 'NF' > manifests/$*/sriov-network-operator-sriovnetwork.crd.yaml
+	@echo ""
+	@echo "*************************************************************************************************************************************************"
+	@echo "* Please manually update the sriov-network-operator.v4.7.0.clusterserviceversion.yaml and image-references files in the manifests/$* directory *"
+	@echo "*************************************************************************************************************************************************"
+	@echo ""
 
 
 # Run go fmt against code

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ IMAGE_BUILDER?=docker
 IMAGE_BUILD_OPTS?=
 DOCKERFILE?=Dockerfile
 
+CRD_BASES=./config/crd/bases
+MANIFESTS_4.7=./manifests/4.7
+
 export APP_NAME=sriov-network-operator
 APP_REPO=github.com/openshift/$(APP_NAME)
 TARGET=$(TARGET_DIR)/bin/$(APP_NAME)
@@ -101,7 +104,12 @@ uninstall: manifests kustomize
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) webhook paths="./..." output:crd:artifacts:config=$(CRD_BASES)
+	cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovibnetworks.yaml 		$(MANIFESTS_4.7)/sriov-network-operator-sriovibnetworks_crd.yaml
+	cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml 	$(MANIFESTS_4.7)/sriov-network-operator-sriovnetworknodepolicy.crd.yaml
+	cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovnetworknodestates.yaml 	$(MANIFESTS_4.7)/sriov-network-operator-sriovnetworknodestate.crd.yaml
+	cp -u $(CRD_BASES)/sriovnetwork.openshift.io_sriovoperatorconfigs.yaml  	$(MANIFESTS_4.7)/sriov-network-operator-sriovoperatorconfig.crd.yaml
+
 
 # Run go fmt against code
 


### PR DESCRIPTION
Automatically copies generated `yaml` files from `./config/crd/bases` to `./manifests/4.7`

**Note:**  the  `./manifests/4.7` dirictory conatins 3 additional files, I've not found thier sources, so they probably should be continue to be manually updated.
The files are:

- sriov-network-operator.v4.7.0.clusterserviceversion.yaml
- sriov-network-operator-sriovnetwork.crd.yaml
- image-references 


Signed-off-by: Alexey Roytman <roytman@il.ibm.com>