### PR TITLE
Bug 1901909: do not set the node selector in the dp / cni daemons if empty in config.

### DIFF
--- a/controllers/sriovoperatorconfig_controller.go
+++ b/controllers/sriovoperatorconfig_controller.go
@@ -208,6 +208,9 @@ func (r *SriovOperatorConfigReconciler) syncPluginDaemonSet(dc *sriovnetworkv1.S
 
 	names := []string{"sriov-cni", "sriov-device-plugin"}
 
+	if len(dc.Spec.ConfigDaemonNodeSelector) == 0 {
+		return nil
+	}
 	for _, name := range names {
 		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, ds)
 		if err != nil {


### PR DESCRIPTION
The reconciliation loop of the policy sets the selector to worker/linux if the one in the config is empty. 
The config reconciliation, on the other hand, sets it to empty. When this happens, a new reconciliation is triggered and the pdos are recreated.

This causes a restart of the dp / cni pods every 5 minutes
