### PR TITLE
Make the clean policies the last operation of clean.Clean.

### DIFF
--- a/test/util/clean/clean.go
+++ b/test/util/clean/clean.go
@@ -21,14 +21,15 @@ func All() error {
 	if !namespaces.Exists(namespaces.Test, clients) {
 		return nil
 	}
-	err := namespaces.Clean(operatorNamespace, namespaces.Test, clients, false)
+	err := namespaces.DeleteAndWait(clients, namespaces.Test, 5*time.Minute)
+	if err != nil {
+		return fmt.Errorf("Failed to delete sriov tests namespace %v", err)
+	}
+
+	err = namespaces.Clean(operatorNamespace, namespaces.Test, clients, false)
 	if err != nil {
 		return fmt.Errorf("Failed to clean sriov resources %v", err)
 	}
 
-	err = namespaces.DeleteAndWait(clients, namespaces.Test, 5*time.Minute)
-	if err != nil {
-		return fmt.Errorf("Failed to delete sriov tests namespace %v", err)
-	}
 	return nil
 }

--- a/test/util/namespaces/namespaces.go
+++ b/test/util/namespaces/namespaces.go
@@ -140,12 +140,16 @@ func Clean(operatorNamespace, namespace string, cs *testclient.ClientSet, discov
 	if err != nil {
 		return err
 	}
-	if !discoveryEnabled {
-		err = CleanPolicies(operatorNamespace, cs)
-		if err != nil {
-			return err
-		}
-	}
 	err = CleanNetworks(operatorNamespace, cs)
-	return err
+	if err != nil {
+		return err
+	}
+	if discoveryEnabled {
+		return nil
+	}
+	err = CleanPolicies(operatorNamespace, cs)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
This allows clients to call sriov stable even in the single node scenario.
By having the policy cleanup the last operation of Clean, we ensure we are able to perform the other cleanings before the node is rebooted, avoiding unwanted errors.
