### PR TITLE
Bug 1898594: Fix the sriov daemon selector assignement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/go-openapi/spec v0.19.4
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/google/go-cmp v0.4.0
 	github.com/intel/sriov-network-device-plugin v3.0.1-0.20191017093954-bf28fdc3e2d9+incompatible
 	github.com/jaypipes/ghw v0.5.0
 	github.com/onsi/ginkgo v1.12.0

--- a/pkg/controller/sriovnetworknodepolicy/sriovnetworknodepolicy_controller.go
+++ b/pkg/controller/sriovnetworknodepolicy/sriovnetworknodepolicy_controller.go
@@ -499,27 +499,7 @@ func (r *ReconcileSriovNetworkNodePolicy) syncDaemonSet(cr *sriovnetworkv1.Sriov
 }
 
 func setDsNodeAffinity(pl *sriovnetworkv1.SriovNetworkNodePolicyList, ds *appsv1.DaemonSet) error {
-	terms := []corev1.NodeSelectorTerm{}
-	for _, p := range pl.Items {
-		nodeSelector := corev1.NodeSelectorTerm{}
-		if len(p.Spec.NodeSelector) == 0 {
-			continue
-		}
-		for k, v := range p.Spec.NodeSelector {
-			expressions := []corev1.NodeSelectorRequirement{}
-			exp := corev1.NodeSelectorRequirement{
-				Operator: corev1.NodeSelectorOpIn,
-				Key:      k,
-				Values:   []string{v},
-			}
-			expressions = append(expressions, exp)
-			nodeSelector = corev1.NodeSelectorTerm{
-				MatchExpressions: expressions,
-			}
-		}
-		terms = append(terms, nodeSelector)
-	}
-
+	terms := nodeSelectorTermsForPolicyList(pl.Items)
 	if len(terms) > 0 {
 		ds.Spec.Template.Spec.Affinity = &corev1.Affinity{
 			NodeAffinity: &corev1.NodeAffinity{
@@ -530,6 +510,36 @@ func setDsNodeAffinity(pl *sriovnetworkv1.SriovNetworkNodePolicyList, ds *appsv1
 		}
 	}
 	return nil
+}
+
+func nodeSelectorTermsForPolicyList(policies []sriovnetworkv1.SriovNetworkNodePolicy) []corev1.NodeSelectorTerm {
+	terms := []corev1.NodeSelectorTerm{}
+	for _, p := range policies {
+		nodeSelector := corev1.NodeSelectorTerm{}
+		if len(p.Spec.NodeSelector) == 0 {
+			continue
+		}
+		expressions := []corev1.NodeSelectorRequirement{}
+		for k, v := range p.Spec.NodeSelector {
+			exp := corev1.NodeSelectorRequirement{
+				Operator: corev1.NodeSelectorOpIn,
+				Key:      k,
+				Values:   []string{v},
+			}
+			expressions = append(expressions, exp)
+		}
+		// sorting is needed to keep the daemon spec stable.
+		// the items are popped in a random order from the map
+		sort.Slice(expressions, func(i, j int) bool {
+			return expressions[i].Key < expressions[j].Key
+		})
+		nodeSelector = corev1.NodeSelectorTerm{
+			MatchExpressions: expressions,
+		}
+		terms = append(terms, nodeSelector)
+	}
+
+	return terms
 }
 
 // renderDsForCR returns a busybox pod with the same name/namespace as the cr

--- a/pkg/controller/sriovnetworknodepolicy/sriovnetworknodepolicy_controller_test.go
+++ b/pkg/controller/sriovnetworknodepolicy/sriovnetworknodepolicy_controller_test.go
@@ -1,0 +1,124 @@
+package sriovnetworknodepolicy
+
+import (
+	"testing"
+
+	sriovnetworkv1 "github.com/openshift/sriov-network-operator/pkg/apis/sriovnetwork/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNodeSelectorMerge(t *testing.T) {
+	table := []struct {
+		tname    string
+		policies []sriovnetworkv1.SriovNetworkNodePolicy
+		expected []corev1.NodeSelectorTerm
+	}{
+		{
+			tname: "testoneselector",
+			policies: []sriovnetworkv1.SriovNetworkNodePolicy{
+				{
+					Spec: sriovnetworkv1.SriovNetworkNodePolicySpec{
+						NodeSelector: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+				{
+					Spec: sriovnetworkv1.SriovNetworkNodePolicySpec{
+						NodeSelector: map[string]string{
+							"bb": "cc",
+						},
+					},
+				},
+			},
+			expected: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Key:      "foo",
+							Values:   []string{"bar"},
+						},
+					},
+				},
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Key:      "bb",
+							Values:   []string{"cc"},
+						},
+					},
+				},
+			},
+		},
+		{
+			tname: "testtwoselectors",
+			policies: []sriovnetworkv1.SriovNetworkNodePolicy{
+				{
+					Spec: sriovnetworkv1.SriovNetworkNodePolicySpec{
+						NodeSelector: map[string]string{
+							"foo":  "bar",
+							"foo1": "bar1",
+						},
+					},
+				},
+				{
+					Spec: sriovnetworkv1.SriovNetworkNodePolicySpec{
+						NodeSelector: map[string]string{
+							"bb":  "cc",
+							"bb1": "cc1",
+							"bb2": "cc2",
+						},
+					},
+				},
+			},
+			expected: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Key:      "foo",
+							Values:   []string{"bar"},
+						},
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Key:      "foo1",
+							Values:   []string{"bar1"},
+						},
+					},
+				},
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Key:      "bb",
+							Values:   []string{"cc"},
+						},
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Key:      "bb1",
+							Values:   []string{"cc1"},
+						},
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Key:      "bb2",
+							Values:   []string{"cc2"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range table {
+		t.Run(tc.tname, func(t *testing.T) {
+			selectors := nodeSelectorTermsForPolicyList(tc.policies)
+			if !cmp.Equal(selectors, tc.expected) {
+				t.Error(tc.tname, "Selectors not as expected", cmp.Diff(selectors, tc.expected))
+			}
+		})
+	}
+}


### PR DESCRIPTION
The current implementation only assigns the first label found in the policy selector.

This causes two issues: do not use the second label specified by the user, and given the fact that the iteration on a map is executed in a random way, the definition of the daemonset is different every reconciliation loop, causing a restart of the pods under the daemonsets.

This is a manual cherry pick of https://github.com/openshift/sriov-network-operator/pull/413