### PR TITLE
Add permissions for configmap change

### DIFF
--- a/bindata/manifests/operator-webhook/002-rbac.yaml
+++ b/bindata/manifests/operator-webhook/002-rbac.yaml
@@ -27,6 +27,13 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+    - ""
+  resources:
+    - configmaps
+  verbs:
+    - get
+    - update
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations

--- a/manifests/4.7/sriov-network-operator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/4.7/sriov-network-operator.v4.7.0.clusterserviceversion.yaml
@@ -263,6 +263,13 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - "get"
+          - "update"
+        - apiGroups:
           - sriovnetwork.openshift.io
           resources:
           - '*'


### PR DESCRIPTION
This commit add the requested permission needed under the csv.

This change was introduce under https://github.com/openshift/sriov-network-operator/pull/416

```
I1214 15:02:04.731639 1393519 daemon.go:197] Could not retrieve Nic Id ConfigMap: configmaps "unsupported-nic-ids" is forbidden: User "system:serviceaccount:openshift-sriov-network-operator:sriov-network-config-daemon" cannot get resource "configmaps" in API group "" in the namespace "openshift-sriov-network-operator"
```

Signed-off-by: Sebastian Sch <sebassch@gmail.com>