### PR TITLE
Bug 1914852: Fix Main PF panic

### DIFF
--- a/test/conformance/tests/sriov_operator.go
+++ b/test/conformance/tests/sriov_operator.go
@@ -1532,6 +1532,10 @@ func discoverResourceForMainSriov(nodes *cluster.EnabledNodes) (*sriovv1.Interfa
 
 		executorPod := createCustomTestPod(node, []string{}, true)
 		mainDevice := findMainSriovDevice(executorPod, nodeDevices)
+		if mainDevice == nil {
+			return nil, "", "", false
+		}
+
 		nodeState, err := clients.SriovNetworkNodeStates(operatorNamespace).Get(context.Background(), node, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		resourceName, ok := findSuitableResourceForMain(mainDevice, nodeState)


### PR DESCRIPTION
This commit fix a panic when the test is not able to find a main PF in discovery mode

```
•! Panic [15.745 seconds]
[sriov] operator
/remote-source/app/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/sriov_operator.go:64
  Custom SriovNetworkNodePolicy
  /remote-source/app/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/sriov_operator.go:827
    Configuration
    /remote-source/app/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/sriov_operator.go:835
      Main PF
      /remote-source/app/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/sriov_operator.go:1044
        should work when vfs are used by pods [It]
        /remote-source/app/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/sriov_operator.go:1045
        Test Panicked
        runtime error: invalid memory address or nil pointer dereference
        /opt/rh/go-toolset-1.13/root/usr/lib/go-toolset-1.13-golang/src/runtime/panic.go:199
        Full Stack Trace
        github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests.findSuitableResourceForMain(0x0, 0xc000a07380, 0x2bb1f40, 0x0, 0x0)
        	/remote-source/app/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/sriov_operator.go:1548 +0xdc
        github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests.discoverResourceForMainSriov(0xc001551680, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        	/remote-source/app/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/sriov_operator.go:1537 +0x421
        github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests.glob..func1.5.2.2.1()
        	/remote-source/app/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/sriov_operator.go:1059 +0x61
        github.com/openshift-kni/cnf-features-deploy/functests_test.TestTest(0xc0004d4d00)
        	/remote-source/app/functests/test_suite_test.go:82 +0xf3
        testing.tRunner(0xc0004d4d00, 0x1b5b280)
        	/opt/rh/go-toolset-1.13/root/usr/lib/go-toolset-1.13-golang/src/testing/testing.go:909 +0xc9
        created by testing.(*T).Run
        	/opt/rh/go-toolset-1.13/root/usr/lib/go-toolset-1.13-golang/src/testing/testing.go:960 +0x350
```

Signed-off-by: Sebastian Sch <sebassch@gmail.com>