### PR TITLE
Increase tests timeout for single node test environments

### DIFF
--- a/test/conformance/tests/sriov_operator.go
+++ b/test/conformance/tests/sriov_operator.go
@@ -41,6 +41,7 @@ import (
 
 var waitingTime time.Duration = 20 * time.Minute
 var sriovNetworkName = "test-sriovnetwork"
+var snoTimeoutMultiplier time.Duration = 0
 
 const (
 	operatorNetworkInjectorFlag = "network-resources-injector"
@@ -65,8 +66,14 @@ var _ = Describe("[sriov] operator", func() {
 	var sriovInfos *cluster.EnabledNodes
 	var initPassed bool
 	execute.BeforeAll(func() {
+		isSingleNode, err := cluster.IsSingleNode(clients)
+		Expect(err).ToNot(HaveOccurred())
+		if isSingleNode {
+			snoTimeoutMultiplier = 1
+		}
+
 		Expect(clients).NotTo(BeNil(), "Client misconfigured, check the $KUBECONFIG env variable")
-		err := namespaces.Create(namespaces.Test, clients)
+		err = namespaces.Create(namespaces.Test, clients)
 		Expect(err).ToNot(HaveOccurred())
 		err = namespaces.Clean(operatorNamespace, namespaces.Test, clients, discovery.Enabled())
 		Expect(err).ToNot(HaveOccurred())
@@ -216,7 +223,7 @@ var _ = Describe("[sriov] operator", func() {
 				Eventually(func() error {
 					netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 					return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: "test-apivolnetwork", Namespace: namespaces.Test}, netAttDef)
-				}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+				}, (10+snoTimeoutMultiplier*110)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 				podDefinition := pod.DefineWithNetworks([]string{sriovNetwork.Name})
 				created, err := clients.Pods(namespaces.Test).Create(context.Background(), podDefinition, metav1.CreateOptions{})
@@ -307,7 +314,7 @@ var _ = Describe("[sriov] operator", func() {
 				netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 				Eventually(func() error {
 					return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: sriovNetwork.Name, Namespace: namespaces.Test}, netAttDef)
-				}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+				}, (10+snoTimeoutMultiplier*110)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 				checkFunc := func(line string) bool {
 					if strings.Contains(line, validationString) {
@@ -522,7 +529,7 @@ var _ = Describe("[sriov] operator", func() {
 					netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 					Eventually(func() error {
 						return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: "test-ratenetwork", Namespace: namespaces.Test}, netAttDef)
-					}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+					}, (10+snoTimeoutMultiplier*110)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 					checkFunc := func(line string) bool {
 						if strings.Contains(line, "max_tx_rate 100Mbps") &&
@@ -558,7 +565,7 @@ var _ = Describe("[sriov] operator", func() {
 					netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 					Eventually(func() error {
 						return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: "test-quosnetwork", Namespace: namespaces.Test}, netAttDef)
-					}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+					}, (10+snoTimeoutMultiplier*110)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 					checkFunc := func(line string) bool {
 						if strings.Contains(line, "vlan 1") &&
@@ -582,7 +589,7 @@ var _ = Describe("[sriov] operator", func() {
 				Eventually(func() error {
 					netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 					return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: sriovNetworkName, Namespace: namespaces.Test}, netAttDef)
-				}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+				}, (10+snoTimeoutMultiplier*110)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 				pod := createTestPod(node, []string{sriovNetworkName, sriovNetworkName})
 				nics, err := network.GetNicsByPrefix(pod, "net")
@@ -601,7 +608,7 @@ var _ = Describe("[sriov] operator", func() {
 				Eventually(func() error {
 					netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 					return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: ipv6NetworkName, Namespace: namespaces.Test}, netAttDef)
-				}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+				}, (10+snoTimeoutMultiplier*110)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 				pod := createTestPod(node, []string{ipv6NetworkName})
 				ips, err := network.GetSriovNicIPs(pod, "net1")
@@ -632,7 +639,7 @@ var _ = Describe("[sriov] operator", func() {
 				Eventually(func() error {
 					netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 					return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: sriovNetworkName, Namespace: ns1}, netAttDef)
-				}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+				}, (30+snoTimeoutMultiplier*90)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 				body, _ := json.Marshal([]patchBody{{
 					Op:    "replace",
@@ -644,7 +651,7 @@ var _ = Describe("[sriov] operator", func() {
 				Eventually(func() error {
 					netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 					return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: sriovNetworkName, Namespace: ns2}, netAttDef)
-				}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+				}, (30+snoTimeoutMultiplier*90)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 				Consistently(func() error {
 					netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 					return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: sriovNetworkName, Namespace: ns1}, netAttDef)
@@ -671,7 +678,7 @@ var _ = Describe("[sriov] operator", func() {
 						return false
 					}
 					return strings.Contains(netAttDef.Spec.Config, "10.11.11.1")
-				}, 30*time.Second, 1*time.Second).Should(BeTrue())
+				}, (30+snoTimeoutMultiplier*90)*time.Second, 1*time.Second).Should(BeTrue())
 
 				sriovNetwork := &sriovv1.SriovNetwork{}
 				err = clients.Get(context.TODO(), runtimeclient.ObjectKey{Name: sriovNetworkName, Namespace: operatorNamespace}, sriovNetwork)
@@ -684,7 +691,7 @@ var _ = Describe("[sriov] operator", func() {
 					netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 					clients.Get(context.Background(), runtimeclient.ObjectKey{Name: sriovNetworkName, Namespace: namespaces.Test}, netAttDef)
 					return strings.Contains(netAttDef.Spec.Config, "10.11.11.100")
-				}, 30*time.Second, 1*time.Second).Should(BeTrue())
+				}, (30+snoTimeoutMultiplier*90)*time.Second, 1*time.Second).Should(BeTrue())
 			})
 		})
 
@@ -697,7 +704,7 @@ var _ = Describe("[sriov] operator", func() {
 				Eventually(func() error {
 					netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 					return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: sriovNetworkName, Namespace: namespaces.Test}, netAttDef)
-				}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+				}, (10+snoTimeoutMultiplier*110)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 				macvlanNadName := "macvlan-nad"
 				macvlanNad := network.CreateMacvlanNetworkAttachmentDefinition(macvlanNadName, namespaces.Test)
@@ -707,7 +714,7 @@ var _ = Describe("[sriov] operator", func() {
 				Eventually(func() error {
 					netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 					return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: macvlanNadName, Namespace: namespaces.Test}, netAttDef)
-				}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+				}, (10+snoTimeoutMultiplier*110)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 				createdPod := createTestPod(node, []string{sriovNetworkName, macvlanNadName})
 
@@ -740,7 +747,7 @@ var _ = Describe("[sriov] operator", func() {
 				Eventually(func() error {
 					netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 					return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: sriovNetworkName, Namespace: namespaces.Test}, netAttDef)
-				}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+				}, (10+snoTimeoutMultiplier*110)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 				testPod := createTestPod(node, []string{sriovNetworkName})
 				stdout, _, err := pod.ExecCommand(clients, testPod, "more", "/proc/sys/net/core/somaxconn")
@@ -767,7 +774,7 @@ var _ = Describe("[sriov] operator", func() {
 				Eventually(func() error {
 					netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 					return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: sriovNetworkName, Namespace: namespaces.Test}, netAttDef)
-				}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+				}, (10+snoTimeoutMultiplier*110)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 				testPodA := pod.RedefineWithNodeSelector(
 					pod.DefineWithNetworks([]string{sriovNetworkName, sriovNetworkName, sriovNetworkName, sriovNetworkName, sriovNetworkName}),
@@ -1066,7 +1073,7 @@ var _ = Describe("[sriov] operator", func() {
 					Eventually(func() error {
 						netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 						return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: sriovNetworkName, Namespace: namespaces.Test}, netAttDef)
-					}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+					}, (10+snoTimeoutMultiplier*110)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 					createTestPod(nodeToTest, []string{sriovNetworkName})
 				})
 			})
@@ -1107,7 +1114,7 @@ var _ = Describe("[sriov] operator", func() {
 					Eventually(func() error {
 						netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 						return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: sriovNetworkName, Namespace: namespaces.Test}, netAttDef)
-					}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+					}, (10+snoTimeoutMultiplier*110)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 					changeNodeInterfaceState(testNode, unusedSriovDevice.Name, false)
 					pod := createTestPod(testNode, []string{sriovNetworkName})
 					ips, err := network.GetSriovNicIPs(pod, "net1")
@@ -1232,7 +1239,7 @@ var _ = Describe("[sriov] operator", func() {
 					Eventually(func() error {
 						netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 						return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: "test-mtuvolnetwork", Namespace: namespaces.Test}, netAttDef)
-					}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+					}, (10+snoTimeoutMultiplier*110)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 				})
 
@@ -1366,7 +1373,7 @@ var _ = Describe("[sriov] operator", func() {
 				Eventually(func() error {
 					netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
 					return clients.Get(context.Background(), runtimeclient.ObjectKey{Name: ipv6NetworkName, Namespace: namespaces.Test}, netAttDef)
-				}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+				}, (10+snoTimeoutMultiplier*110)*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 				By("creating a pod")
 				pod := createTestPod(node, []string{ipv6NetworkName})
@@ -1840,7 +1847,7 @@ func waitForSRIOVStable() {
 	// the status won't never go to not stable and the test will fail.
 	// TODO: find a better way to handle this scenario
 
-	time.Sleep(10 * time.Second)
+	time.Sleep((10 + snoTimeoutMultiplier*20) * time.Second)
 
 	fmt.Println("Waiting for the sriov state to stable")
 	Eventually(func() bool {

--- a/test/util/cluster/cluster.go
+++ b/test/util/cluster/cluster.go
@@ -190,3 +190,13 @@ func IsClusterStable(clients *testclient.ClientSet) (bool, error) {
 
 	return true, nil
 }
+
+// IsSingleNode validates if the environment is single node cluster
+// This is done by checking numer of nodes, it can later be substituted by an env variable if needed
+func IsSingleNode(clients *testclient.ClientSet) (bool, error) {
+	nodes, err := clients.Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+	return len(nodes.Items) == 1, nil
+}


### PR DESCRIPTION
Single node environments can take much longer to stabilize than environment with multiple nodes. This can cause existing tests to fail due to the timeouts not being long enough. This PR increases the timeouts if a single node environment is detected.