### PR TITLE
[release-4.7] Change must-gather/Dockerfile.rhel7 to use must-gather image

### DIFF
--- a/must-gather/Dockerfile.rhel7
+++ b/must-gather/Dockerfile.rhel7
@@ -2,7 +2,7 @@ FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 
 WORKDIR /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator
 COPY . .
 
-FROM registry.svc.ci.openshift.org/ocp/4.7:cli
+FROM registry.ci.openshift.org/ocp/4.7:must-gather
 LABEL io.k8s.display-name="sriov-network-operator-must-gather" \
       io.k8s.description="This is a sriov must-gather image that collectes sriov network operator related resources."
 COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator/must-gather/collection-scripts/* /usr/bin/


### PR DESCRIPTION
This should fix the problem of oc adm must-gather not finding oc binary