### PR TITLE
Add management workload annotations

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -14,6 +14,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: sriov-network-config-daemon
         component: network

--- a/bindata/manifests/operator-webhook/server.yaml
+++ b/bindata/manifests/operator-webhook/server.yaml
@@ -18,6 +18,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: operator-webhook
     spec:

--- a/bindata/manifests/plugins/sriov-cni.yaml
+++ b/bindata/manifests/plugins/sriov-cni.yaml
@@ -16,6 +16,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: sriov-cni
         component: network

--- a/bindata/manifests/plugins/sriov-device-plugin.yaml
+++ b/bindata/manifests/plugins/sriov-device-plugin.yaml
@@ -16,6 +16,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: sriov-device-plugin
         component: network

--- a/bindata/manifests/webhook/server.yaml
+++ b/bindata/manifests/webhook/server.yaml
@@ -18,6 +18,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: network-resources-injector
         component: network

--- a/manifests/4.8/sriov-network-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/sriov-network-operator.v4.8.0.clusterserviceversion.yaml
@@ -297,6 +297,8 @@ spec:
               name: sriov-network-operator
           template:
             metadata:
+              annotations:
+                workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: sriov-network-operator
             spec:


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.