### PR TITLE
Bug 1949202: Add metadata for ppc64le

### DIFF
--- a/manifests/4.8/sriov-network-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/sriov-network-operator.v4.8.0.clusterserviceversion.yaml
@@ -371,6 +371,8 @@ spec:
   labels:
     olm-owner-enterprise-app: sriov-network-operator
     olm-status-descriptors: sriov-network-operator.v4.8.0
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
   maintainers:
   - email: support@redhat.com
     name: Red Hat


### PR DESCRIPTION
Add metadata to indicate availability of sriov-network-operator on the ppc64le architecture.