### PR TITLE
Bug 1966561: add OLM bug workaround for workload partitioning

### DIFF
--- a/manifests/4.8/sriov-network-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/sriov-network-operator.v4.8.0.clusterserviceversion.yaml
@@ -4,6 +4,10 @@ metadata:
   name: sriov-network-operator.v4.8.0
   namespace: openshift-sriov-network-operator
   annotations:
+    # This annotation injection is a workaround for BZ-1950047, since the associated
+    # annotation in spec.install.spec.deployments.template.metadata is presently ignored.
+    # TODO: remove the next line after BZ-1950047 is resolved.
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     alm-examples: |
       [
         {


### PR DESCRIPTION
PR #495 added annotations
required for supporting the workload partitioning feature for ocp 4.8.
However, OLM has a bug in processing the annotations (BZ 1950047).
This PR provides a workaround necessary to release the workload
partitioning in OCP 4.8.