### PR TITLE
Bug 1966620: Add an openshift specific bundle to use for CI

### DIFF
--- a/bundleci.Dockerfile
+++ b/bundleci.Dockerfile
@@ -1,0 +1,16 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=sriov-network-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channel.default.v1=
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.0.1
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v2
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+
+COPY manifests/4.8 /manifests/
+COPY bundle/metadata /metadata/


### PR DESCRIPTION
The current one copies bundle/manifests which is not what we use for CI.
Here we add a new one to serve CI purpouses.

