### PR TITLE
Bug 1993007: Use GlobalMgr for SriovNetwork controllers

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,14 +102,14 @@ func main() {
 	if err = (&controllers.SriovNetworkReconciler{
 		Client: mgrGlobal.GetClient(),
 		Scheme: mgrGlobal.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgrGlobal); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SriovNetwork")
 		os.Exit(1)
 	}
 	if err = (&controllers.SriovIBNetworkReconciler{
 		Client: mgrGlobal.GetClient(),
 		Scheme: mgrGlobal.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgrGlobal); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SriovIBNetwork")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Using 2 managers for the same controllers causes inconsistency in
objects reconcilation. For example we saw a problem with some SriovNetwork
update events not reaching the controller (Reconcile was not triggered).
Using the same Mgr as the specified client for the controller solves these kind of problems.

Cherry-pick from https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/175

Signed-off-by: Ori Braunshtein <obraunsh@redhat.com>