### PR TITLE
Bug 1994997: Fix olm.skipRange substitution

### DIFF
--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -6,8 +6,8 @@ updates:
       replace: "sriov-network-operator.{FULL_VER}"
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"
-    - search: 'olm.skipRange: ">=4.3.0-0 <{MAJOR}.{MINOR}.0"'
-      replace: 'olm.skipRange: ">=4.3.0-0 <{FULL_VER}"'
+    - search: "olm.skipRange: '>=4.3.0-0 <{MAJOR}.{MINOR}.0'"
+      replace: "olm.skipRange: '>=4.3.0-0 <{FULL_VER}'"
   - file: "sriov-network-operator.package.yaml"
     update_list:
     - search: "currentCSV: sriov-network-operator.v{MAJOR}.{MINOR}.0"


### PR DESCRIPTION
Currently, the skipRange substitution for product builds is a noop.
This change should fix that.