### PR TITLE
Bug 2029867: backport for allowing netFilter to be set alone in NicSelector

### DIFF
--- a/pkg/webhook/validate.go
+++ b/pkg/webhook/validate.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"k8s.io/api/admission/v1"
+	v1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -89,8 +89,8 @@ func staticValidateSriovNetworkNodePolicy(cr *sriovnetworkv1.SriovNetworkNodePol
 		return false, fmt.Errorf("resource name \"%s\" contains invalid characters, the accepted syntax of the regular expressions is: \"^[a-zA-Z0-9_]+$\"", cr.Spec.ResourceName)
 	}
 
-	if cr.Spec.NicSelector.Vendor == "" && cr.Spec.NicSelector.DeviceID == "" && len(cr.Spec.NicSelector.PfNames) == 0 && len(cr.Spec.NicSelector.RootDevices) == 0 {
-		return false, fmt.Errorf("at least one of these parameters (vendor, deviceID, pfNames or rootDevices) has to be defined in nicSelector in CR %s", cr.GetName())
+	if cr.Spec.NicSelector.Vendor == "" && cr.Spec.NicSelector.DeviceID == "" && len(cr.Spec.NicSelector.PfNames) == 0 && len(cr.Spec.NicSelector.RootDevices) == 0 && cr.Spec.NicSelector.NetFilter == "" {
+		return false, fmt.Errorf("at least one of these parameters (vendor, deviceID, pfNames, rootDevices or netFilter) has to be defined in nicSelector in CR %s", cr.GetName())
 	}
 
 	if cr.Spec.NicSelector.Vendor != "" {

--- a/pkg/webhook/validate_test.go
+++ b/pkg/webhook/validate_test.go
@@ -492,3 +492,27 @@ func TestStaticValidateSriovNetworkNodePolicyWithInvalidNicSelector(t *testing.T
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(ok).To(Equal(false))
 }
+
+func TestValidatePolicyForNodeStateWithValidNetFilter(t *testing.T) {
+	interfaceSelected = false
+	state := newNodeState()
+	policy := &SriovNetworkNodePolicy{
+		Spec: SriovNetworkNodePolicySpec{
+			DeviceType: "netdevice",
+			NicSelector: SriovNetworkNicSelector{
+				NetFilter: "openstack/NetworkID:ada9ec67-2c97-467c-b674-c47200e2f5da",
+			},
+			NodeSelector: map[string]string{
+				"feature.node.kubernetes.io/network-sriov.capable": "true",
+			},
+			NumVfs:       63,
+			Priority:     99,
+			ResourceName: "p0",
+		},
+	}
+	g := NewGomegaWithT(t)
+	ok, err := validatePolicyForNodeState(policy, state)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ok).To(Equal(true))
+	g.Expect(interfaceSelected).To(Equal(true))
+}


### PR DESCRIPTION
Backport of
https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/210.

In `staticValidateSriovNetworkNodePolicy`, we now allow a NicSelector to
only have NetFilter defined.

This will be useful for the OpenStack platform, where we can request a
Network Node Policy only by its Network ID.
