### PR TITLE
Bug 2033129: Run generic plugin Apply when no vender plugin loaded

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -528,11 +528,14 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 	}
 
 	if !reqReboot {
-		// Apply generic_plugin last
-		err = dn.LoadedPlugins[GenericPlugin].Apply()
-		if err != nil {
-			glog.Errorf("nodeStateSyncHandler(): generic_plugin fail to apply: %v", err)
-			return err
+		plugin, ok := dn.LoadedPlugins[GenericPlugin]
+		if ok {
+			// Apply generic_plugin last
+			err = plugin.Apply()
+			if err != nil {
+				glog.Errorf("nodeStateSyncHandler(): generic_plugin fail to apply: %v", err)
+				return err
+			}
 		}
 	}
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -527,7 +527,7 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 		}
 	}
 
-	if len(dn.LoadedPlugins) > 1 && !reqReboot {
+	if !reqReboot {
 		// Apply generic_plugin last
 		err = dn.LoadedPlugins[GenericPlugin].Apply()
 		if err != nil {


### PR DESCRIPTION
Fix the issue that generic plugin Apply won't be invoked if no supported
vendor NICs in the host.

(cherry picked from commit 1d954a5304283f62808abbe13c55c6dd7b2b4083)