### PR TITLE
Bug 2040122: [Release 4.9] Reload VF driver only when rdma is enabled

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -338,6 +338,7 @@ func (p *SriovNetworkNodePolicy) generateVfGroup(iface *InterfaceExt) (*VfGroup,
 		VfRange:      rng,
 		PolicyName:   p.GetName(),
 		Mtu:          p.Spec.Mtu,
+		IsRdma:       p.Spec.IsRdma,
 	}, nil
 }
 

--- a/api/v1/sriovnetworknodestate_types.go
+++ b/api/v1/sriovnetworknodestate_types.go
@@ -45,6 +45,7 @@ type VfGroup struct {
 	VfRange      string `json:"vfRange,omitempty"`
 	PolicyName   string `json:"policyName,omitempty"`
 	Mtu          int    `json:"mtu,omitempty"`
+	IsRdma       bool   `json:"isRdma,omitempty"`
 }
 
 type Interfaces []Interface

--- a/bundle/manifests/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/bundle/manifests/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -57,6 +57,8 @@ spec:
                         properties:
                           deviceType:
                             type: string
+                          isRdma:
+                            type: boolean
                           mtu:
                             type: integer
                           policyName:

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -59,6 +59,8 @@ spec:
                         properties:
                           deviceType:
                             type: string
+                          isRdma:
+                            type: boolean
                           mtu:
                             type: integer
                           policyName:

--- a/manifests/4.9/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/manifests/4.9/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -57,6 +57,8 @@ spec:
                         properties:
                           deviceType:
                             type: string
+                          isRdma:
+                            type: boolean
                           mtu:
                             type: integer
                           policyName:


### PR DESCRIPTION
To set the GUID to VF, we need to set the admin MAC and reload the
VF driver. It will take a long time if users set big 'numVFs'. This
PR changes the logic to only reload the VF driver when isRdma is
set. So that, users not using ROCE will no longer need to wait for
the VF driver reload.