### PR TITLE
Bug 2072498: fix make bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,13 +158,14 @@ skopeo:
 .PHONY: bundle
 bundle: manifests
 	rm -f bundle/manifests/*
-	rm -f manifests/4.10/*.yaml
+	MANIFEST_YAML=$$(ls manifests/4.10/*.yaml | grep -v supported-nic-ids_v1_configmap.yaml) ; \
+	rm -f $$MANIFEST_YAML
 	operator-sdk generate kustomize manifests --interactive=false -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS) --extra-service-accounts sriov-network-config-daemon
 	operator-sdk bundle validate ./bundle
-	cp bundle/manifests/* manifests/4.10
-
+	BUNDLE_MANIFEST_YAML=$$(ls bundle/manifests/* | grep -v supported-nic-ids_v1_configmap.yaml); \
+	cp $$BUNDLE_MANIFEST_YAML manifests/4.10
 # Build the bundle image.
 .PHONY: bundle-build
 bundle-build:


### PR DESCRIPTION
Don't overwrite the supported NICs downstream. We maintain a different
list of NICs than upstream does.