### PR TITLE
Update Makefile for go 1.18 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,12 +129,16 @@ generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
+CONTROLLER_GEN_PKG = sigs.k8s.io/controller-tools/cmd/controller-gen
+CONTROLLER_GEN_VER = v0.4.1
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
+	$(call go-get-tool,$(CONTROLLER_GEN),$(CONTROLLER_GEN_PKG),$(CONTROLLER_GEN_VER))
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
+KUSTOMIZE_PKG = sigs.k8s.io/kustomize/kustomize/v3
+KUSTOMIZE_VER = v3.8.7
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),$(KUSTOMIZE_PKG),$(KUSTOMIZE_VER))
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -144,8 +148,9 @@ set -e ;\
 TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+echo "Downloading $(2)@$(3)" ;\
+GOBIN=$(PROJECT_DIR)/bin go get -d $(2)@$(3) ;\
+GOFLAGS=$(filter-out -mod=vendor,$(GOFLAGS)) GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
In go 1.18, the "go get" command no longer installs the module. This
effectively makes every "go get" command having the "-d" option turned
on implicitly. The solution is to now explicitly add "-d" to "go get"
for backwards compatibility with go versions <1.18. Then the module
is installed by the "go install" following step.