### PR TITLE
Bug 2095210: [release 4.8] Don't check MCP state when node in Draining_MCP_Paused state

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -890,9 +890,14 @@ func (dn *Daemon) drainNode(name string) error {
 				mcpEventHandler(new)
 			},
 		})
-		mcpInformerFactory.Start(ctx.Done())
-		mcpInformerFactory.WaitForCacheSync(ctx.Done())
-		<-ctx.Done()
+
+		// The Draining_MCP_Paused state means the MCP work has been paused by the config daemon in previous round.
+		// Only check MCP state if the node is not in Draining_MCP_Paused state
+		if !paused {
+			mcpInformerFactory.Start(ctx.Done())
+			mcpInformerFactory.WaitForCacheSync(ctx.Done())
+			<-ctx.Done()
+		}
 	}
 
 	backoff := wait.Backoff{


### PR DESCRIPTION
Signed-off-by: Sebastian Sch <sebassch@gmail.com>