### PR TITLE
Make tolerations compatible with Kubernetes newer than 1.20

### DIFF
--- a/bindata/manifests/operator-webhook/server.yaml
+++ b/bindata/manifests/operator-webhook/server.yaml
@@ -34,15 +34,16 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/master
                 operator: Exists
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: Exists
+      - operator: Exists
         effect: NoSchedule
-      - key: "node.kubernetes.io/not-ready"
-        operator: Exists
-        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
       containers:
       - name: webhook-server
         image: {{.SriovNetworkWebhookImage}}

--- a/bindata/manifests/webhook/server.yaml
+++ b/bindata/manifests/webhook/server.yaml
@@ -37,15 +37,16 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/master
                 operator: Exists
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: Exists
+      - operator: Exists
         effect: NoSchedule
-      - key: "node.kubernetes.io/not-ready"
-        operator: Exists
-        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
       containers:
       - name: webhook-server
         image: {{.NetworkResourcesInjectorImage}}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -21,12 +21,16 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
               - key: node-role.kubernetes.io/master
                 operator: Exists
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
       serviceAccountName: sriov-network-operator
       priorityClassName: "system-node-critical"
       containers:


### PR DESCRIPTION
Kubernetes 1.20 deprecated the label `node-role.kubernetes.io/master` on the control-plane nodes. Instead of that, `node-role.kubernetes.io/control-plane` should be used. Also, control-plane nodes may have multiple taints (for example, for `node-role.kubernetes.io/etcd`), where SRIOV-related DaemonSets try to avoid them.

There are two options to have more control over where DaemonSets are deployed:
1. Make `affinity` and `tolerations` configurable
1. Ignore all `taints` on the control-plane nodes

This PR introduces option 2 as a quick fix to enable deployment of SRIOV on the latest Kubernetes installations.

Closes #679 