### PR TITLE
[release-4.11] OCPBUGS-694: Remove must gather

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,8 +70,6 @@ spec:
             value: quay.io/openshift/origin-sriov-network-webhook:4.11
           - name: SRIOV_INFINIBAND_CNI_IMAGE
             value: quay.io/openshift/origin-sriov-infiniband-cni:4.11
-          - name: SRIOV_OPERATOR_MUST_GATHER_IMAGE
-            value: quay.io/openshift/origin-sriov-operator-must-gather:4.11
           - name: RESOURCE_PREFIX
             value: openshift.io
           - name: ENABLE_ADMISSION_CONTROLLER

--- a/config/manifests/bases/sriov-network-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sriov-network-operator.clusterserviceversion.yaml
@@ -125,8 +125,6 @@ spec:
                   value: quay.io/openshift/origin-sriov-network-webhook:4.11
                 - name: SRIOV_INFINIBAND_CNI_IMAGE
                   value: quay.io/openshift/origin-sriov-infiniband-cni:4.11
-                - name: SRIOV_OPERATOR_MUST_GATHER_IMAGE
-                  value: quay.io/openshift/origin-sriov-operator-must-gather:4.11
                 - name: RESOURCE_PREFIX
                   value: openshift.io
                 - name: ENABLE_ADMISSION_CONTROLLER

--- a/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
+++ b/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
@@ -333,8 +333,6 @@ spec:
                   value: quay.io/openshift/origin-sriov-network-webhook:4.11
                 - name: SRIOV_INFINIBAND_CNI_IMAGE
                   value: quay.io/openshift/origin-sriov-infiniband-cni:4.11
-                - name: SRIOV_OPERATOR_MUST_GATHER_IMAGE
-                  value: quay.io/openshift/origin-sriov-operator-must-gather:4.11
                 - name: RESOURCE_PREFIX
                   value: openshift.io
                 - name: ENABLE_ADMISSION_CONTROLLER


### PR DESCRIPTION
This backport is about cleaning the unused `SRIOV_OPERATOR_MUST_GATHER_IMAGE` environment variables from deployment files.