### PR TITLE
NHE-203: Add Nvidia MLX5 ConnectX-6 Lx Support

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -20,6 +20,7 @@ data:
   Nvidia_mlx5_ConnectX-5_Ex: "15b3 1019 101a"
   Nvidia_mlx5_ConnectX-6: "15b3 101b 101c"
   Nvidia_mlx5_ConnectX-6_Dx: "15b3 101d 101e"
+  Nvidia_mlx5_ConnectX-6_Lx: "15b3 101f 101e"
   Nvidia_mlx5_MT42822_BlueField-2_integrated_ConnectX-6_Dx: "15b3 a2d6 101e"
   Broadcom_bnxt_BCM57414_2x25G: "14e4 16d7 16dc"
   Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"

--- a/deployment/sriov-network-operator/templates/configmap.yaml
+++ b/deployment/sriov-network-operator/templates/configmap.yaml
@@ -20,6 +20,7 @@ data:
   Nvidia_mlx5_ConnectX-5_Ex: "15b3 1019 101a"
   Nvidia_mlx5_ConnectX-6: "15b3 101b 101c"
   Nvidia_mlx5_ConnectX-6_Dx: "15b3 101d 101e"
+  Nvidia_mlx5_ConnectX-6_Lx: "15b3 101f 101e"
   Nvidia_mlx5_MT42822_BlueField-2_integrated_ConnectX-6_Dx: "15b3 a2d6 101e"
   Broadcom_bnxt_BCM57414_2x25G: "14e4 16d7 16dc"
   Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"

--- a/doc/supported-hardware.md
+++ b/doc/supported-hardware.md
@@ -16,6 +16,7 @@ The following SR-IOV capable hardware is supported with sriov-network-operator:
 | Mellanox MT28800 Family [ConnectX-5 Ex] | 15b3 | 1019 |
 | Mellanox MT28908 Family [ConnectX-6] | 15b3 | 101b |
 | Mellanox MT28908 Family [ConnectX-6 Dx] | 15b3 | 101d |
+| Mellanox MT28908 Family [ConnectX-6 Lx] | 15b3 | 101f |
 | Mellanox MT42822 BlueField-2 integrated ConnectX-6 Dx | 15b3 | a2d6 |
 | Qlogic QL45000 Series 50GbE Controller | 1077 | 1654 |
 
@@ -44,6 +45,7 @@ The following table depicts the supported SR-IOV hardware features of each suppo
 | Mellanox MT28800 Family [ConnectX-5 Ex] | V | V | V |
 | Mellanox MT28908 Family [ConnectX-6] | V | V | V |
 | Mellanox MT28908 Family [ConnectX-6 Dx] | V | V | V |
+| Mellanox MT28908 Family [ConnectX-6 Lx] | V | V | V |
 | Mellanox MT42822 BlueField-2 integrated ConnectX-6 Dx | V | V | V |
 | Qlogic QL45000 Series 50GbE Controller | V | X | X |
 


### PR DESCRIPTION
ConnectX-6 Lx support is currently available upstream.

Signed-off-by: William Zhao <wizhao@redhat.com>