### PR TITLE
OCPBUGS-1235: Add missing Red Hat Virtio network device into supported nics

### DIFF
--- a/bundle/manifests/supported-nic-ids_v1_configmap.yaml
+++ b/bundle/manifests/supported-nic-ids_v1_configmap.yaml
@@ -26,6 +26,7 @@ data:
   Qlogic_qede_QL41000: 1077 8070 8090
   Qlogic_qede_QL45000_25G: 1077 1656 1664
   Qlogic_qede_QL45000_50G: 1077 1654 1664
+  Red_Hat_Virtio_network_device: 1af4 1000 1000
 kind: ConfigMap
 metadata:
   name: supported-nic-ids

--- a/config/manifests/bases/sriov-network-operator_configmap.yaml
+++ b/config/manifests/bases/sriov-network-operator_configmap.yaml
@@ -29,3 +29,4 @@ data:
   Qlogic_qede_QL41000: "1077 8070 8090"
   Qlogic_qede_QL45000_25G: "1077 1656 1664"
   Qlogic_qede_QL45000_50G: "1077 1654 1664"
+  Red_Hat_Virtio_network_device: "1af4 1000 1000"


### PR DESCRIPTION
We had this NIC supported in previous releases, and it was missed in 4.12 probably due to a bad copy/paste.
We need this NIC to be supported, for the virtualized environments (e.g. OpenStack).