### PR TITLE
Sync k8snetworkplumbingwg/master 2022_09_22

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -26,3 +26,8 @@ data:
   Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"
   Qlogic_qede_QL45000_50G: "1077 1654 1664"
   Red_Hat_Virtio_network_device: "1af4 1000 1000"
+  Marvell_OCTEON_TX2_CN96XX: "177d b200 b203"
+  Marvell_OCTEON_TX2_CN98XX: "177d b100 b103"
+  Marvell_OCTEON_Fusion_CNF95XX: "177d b600 b603"
+  Marvell_OCTEON10_CN10XXX: "177d b900 b903"
+  Marvell_OCTEON_Fusion_CNF105XX: "177d ba00 ba03"

--- a/deployment/sriov-network-operator/templates/configmap.yaml
+++ b/deployment/sriov-network-operator/templates/configmap.yaml
@@ -26,3 +26,8 @@ data:
   Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"
   Qlogic_qede_QL45000_50G: "1077 1654 1664"
   Red_Hat_Virtio_network_device: "1af4 1000 1000"
+  Marvell_OCTEON_TX2_CN96XX: "177d b200 b203"
+  Marvell_OCTEON_TX2_CN98XX: "177d b100 b103"
+  Marvell_OCTEON_Fusion_CNF95XX: "177d b600 b603"
+  Marvell_OCTEON10_CN10XXX: "177d b900 b903"
+  Marvell_OCTEON_Fusion_CNF105XX: "177d ba00 ba03"

--- a/doc/supported-hardware.md
+++ b/doc/supported-hardware.md
@@ -19,6 +19,11 @@ The following SR-IOV capable hardware is supported with sriov-network-operator:
 | Mellanox MT28908 Family [ConnectX-6 Lx] | 15b3 | 101f |
 | Mellanox MT42822 BlueField-2 integrated ConnectX-6 Dx | 15b3 | a2d6 |
 | Qlogic QL45000 Series 50GbE Controller | 1077 | 1654 |
+| Marvell OCTEON TX2 CN96XX | 177d | b200 |
+| Marvell OCTEON TX2 CN98XX | 177d | b100 |
+| Marvell OCTEON Fusion CNF95XX | 177d | b600 |
+| Marvell OCTEON 10 CN10XXX | 177d | b900 |
+| Marvell OCTEON Fusion CNF105XX | 177d | ba00 |
 
 > **Note:** sriov-network-operator maintains a list of supported NICs which it supports.
 > These are stored in supported-nic-ids [configMap](https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/master/deployment/sriov-network-operator/templates/configmap.yaml).
@@ -48,6 +53,11 @@ The following table depicts the supported SR-IOV hardware features of each suppo
 | Mellanox MT28908 Family [ConnectX-6 Lx] | V | V | V |
 | Mellanox MT42822 BlueField-2 integrated ConnectX-6 Dx | V | V | V |
 | Qlogic QL45000 Series 50GbE Controller | V | X | X |
+| Marvell OCTEON TX2 CN96XX | V | V | X |
+| Marvell OCTEON TX2 CN98XX | V | V | X |
+| Marvell OCTEON Fusion CNF95XX | V | V | X |
+| Marvell OCTEON 10 CN10XXX | V | V | X |
+| Marvell OCTEON Fusion CNF105XX | V | V | X |
 
 # Adding new Hardware
 

--- a/doc/vendor-support.md
+++ b/doc/vendor-support.md
@@ -12,4 +12,4 @@ as `active-in-project` in the table below.
 | Nvidia(Mellanox) | active-in-project |
 | Intel | active-in-project |
 | HPE(Marvell Qlogic) | BSN_dev_support@hpe.com |
-
+| Marvell | navadiaev@marvell.com |

--- a/pkg/plugins/generic/generic_plugin.go
+++ b/pkg/plugins/generic/generic_plugin.go
@@ -88,12 +88,21 @@ func (p *GenericPlugin) Apply() error {
 			return nil
 		}
 	}
+
+	// Create a map with all the PFs we will need to configure
+	// we need to create it here before we access the host file system using the chroot function
+	// because the skipConfigVf needs the mstconfig package that exist only inside the sriov-config-daemon file system
+	pfsToSkip, err := utils.GetPfsToSkip(p.DesireState)
+	if err != nil {
+		return err
+	}
+
 	exit, err := utils.Chroot("/host")
 	if err != nil {
 		return err
 	}
 	defer exit()
-	if err := utils.SyncNodeState(p.DesireState); err != nil {
+	if err := utils.SyncNodeState(p.DesireState, pfsToSkip); err != nil {
 		return err
 	}
 	p.LastState = &sriovnetworkv1.SriovNetworkNodeState{}

--- a/pkg/plugins/generic/generic_plugin.go
+++ b/pkg/plugins/generic/generic_plugin.go
@@ -159,13 +159,8 @@ func needDrainNode(desired sriovnetworkv1.Interfaces, current sriovnetworkv1.Int
 				// TODO: no need to perform further checks if ifaceStatus.NumVfs equals to 0
 				// once https://github.com/kubernetes/kubernetes/issues/109595 will be fixed
 				configured = true
-				if iface.NumVfs != ifaceStatus.NumVfs {
-					glog.V(2).Infof("generic-plugin needDrainNode(): need drain, expect NumVfs %v, current NumVfs %v", iface.NumVfs, ifaceStatus.NumVfs)
-					needDrain = true
-					return
-				}
-				if iface.Mtu != 0 && iface.Mtu != ifaceStatus.Mtu {
-					glog.V(2).Infof("generic-plugin needDrainNode(): need drain, expect MTU %v, current MTU %v", iface.Mtu, ifaceStatus.Mtu)
+				if utils.NeedUpdate(&iface, &ifaceStatus) {
+					glog.V(2).Infof("generic-plugin needDrainNode(): need drain, PF %s request update", iface.PciAddress)
 					needDrain = true
 					return
 				}

--- a/pkg/plugins/generic/generic_plugin_test.go
+++ b/pkg/plugins/generic/generic_plugin_test.go
@@ -1,0 +1,131 @@
+package generic_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	plugin "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/plugins"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/plugins/generic"
+)
+
+func TestGenericPlugin(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Generic Plugin")
+}
+
+var _ = Describe("Generic plugin", func() {
+	var genericPlugin plugin.VendorPlugin
+	var err error
+	BeforeEach(func() {
+		genericPlugin, err = generic.NewGenericPlugin()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("OnNodeStateChange", func() {
+		It("should not drain", func() {
+			networkNodeState := &sriovnetworkv1.SriovNetworkNodeState{
+				Spec: sriovnetworkv1.SriovNetworkNodeStateSpec{
+					Interfaces: sriovnetworkv1.Interfaces{{
+						PciAddress: "0000:00:00.0",
+						NumVfs:     1,
+						VfGroups: []sriovnetworkv1.VfGroup{{
+							DeviceType:   "netdevice",
+							PolicyName:   "policy-1",
+							ResourceName: "resource-1",
+							VfRange:      "0-0",
+						}}}},
+				},
+				Status: sriovnetworkv1.SriovNetworkNodeStateStatus{
+					Interfaces: sriovnetworkv1.InterfaceExts{{
+						PciAddress:  "0000:00:00.0",
+						NumVfs:      1,
+						TotalVfs:    1,
+						DeviceID:    "1015",
+						Vendor:      "15b3",
+						Name:        "sriovif1",
+						Mtu:         1500,
+						Mac:         "0c:42:a1:55:ee:46",
+						Driver:      "mlx5_core",
+						EswitchMode: "legacy",
+						LinkSpeed:   "25000 Mb/s",
+						LinkType:    "ETH",
+						VFs: []sriovnetworkv1.VirtualFunction{{
+							PciAddress: "0000:00:00.1",
+							DeviceID:   "1016",
+							Vendor:     "15b3",
+							VfID:       0,
+							Name:       "sriovif1v0",
+							Mtu:        1500,
+							Mac:        "8e:d6:2c:62:87:1b",
+							Driver:     "mlx5_core",
+						}},
+					}},
+				},
+			}
+
+			needDrain, needReboot, err := genericPlugin.OnNodeStateChange(networkNodeState)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needReboot).To(BeFalse())
+			Expect(needDrain).To(BeFalse())
+		})
+
+		It("should drain", func() {
+			networkNodeState := &sriovnetworkv1.SriovNetworkNodeState{
+				Spec: sriovnetworkv1.SriovNetworkNodeStateSpec{
+					Interfaces: sriovnetworkv1.Interfaces{{
+						PciAddress: "0000:00:00.0",
+						NumVfs:     2,
+						Mtu:        1500,
+						VfGroups: []sriovnetworkv1.VfGroup{{
+							DeviceType:   "netdevice",
+							PolicyName:   "policy-1",
+							ResourceName: "resource-1",
+							VfRange:      "0-1",
+							Mtu:          1500,
+						}}}},
+				},
+				Status: sriovnetworkv1.SriovNetworkNodeStateStatus{
+					Interfaces: sriovnetworkv1.InterfaceExts{{
+						PciAddress:  "0000:00:00.0",
+						NumVfs:      2,
+						TotalVfs:    2,
+						DeviceID:    "1015",
+						Vendor:      "15b3",
+						Name:        "sriovif1",
+						Mtu:         1500,
+						Mac:         "0c:42:a1:55:ee:46",
+						Driver:      "mlx5_core",
+						EswitchMode: "legacy",
+						LinkSpeed:   "25000 Mb/s",
+						LinkType:    "ETH",
+						VFs: []sriovnetworkv1.VirtualFunction{{
+							PciAddress: "0000:00:00.1",
+							DeviceID:   "1016",
+							Vendor:     "15b3",
+							VfID:       0,
+							Driver:     "mlx5_core",
+							Name:       "sriovif1v0",
+							Mtu:        999, // Bad MTU value, changed by the user application
+							Mac:        "8e:d6:2c:62:87:1b",
+						}, {
+							PciAddress: "0000:00:00.2",
+							DeviceID:   "1016",
+							Vendor:     "15b3",
+							VfID:       0,
+							Driver:     "mlx5_core",
+						}},
+					}},
+				},
+			}
+
+			needDrain, needReboot, err := genericPlugin.OnNodeStateChange(networkNodeState)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needReboot).To(BeFalse())
+			Expect(needDrain).To(BeTrue())
+		})
+	})
+
+})

--- a/pkg/utils/switchdev.go
+++ b/pkg/utils/switchdev.go
@@ -58,6 +58,7 @@ func WriteSwitchdevConfFile(newState *sriovnetworkv1.SriovNetworkNodeState) (upd
 	if err != nil {
 		if os.IsNotExist(err) {
 			if len(cfg.Interfaces) == 0 {
+				err = nil
 				return
 			}
 			glog.V(2).Infof("WriteSwitchdevConfFile(): file not existed, create it")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -162,7 +162,7 @@ func SyncNodeState(newState *sriovnetworkv1.SriovNetworkNodeState) error {
 					glog.V(2).Infof("syncNodeState(): skip config VF in config daemon for %s, it shall be done by switchdev-configuration.service", iface.PciAddress)
 					break
 				}
-				if !needUpdate(&iface, &ifaceStatus) {
+				if !NeedUpdate(&iface, &ifaceStatus) {
 					glog.V(2).Infof("syncNodeState(): no need update interface %s", iface.PciAddress)
 					break
 				}
@@ -199,17 +199,17 @@ func SkipConfigVf(ifSpec sriovnetworkv1.Interface, ifStatus sriovnetworkv1.Inter
 	return false
 }
 
-func needUpdate(iface *sriovnetworkv1.Interface, ifaceStatus *sriovnetworkv1.InterfaceExt) bool {
+func NeedUpdate(iface *sriovnetworkv1.Interface, ifaceStatus *sriovnetworkv1.InterfaceExt) bool {
 	if iface.Mtu > 0 {
 		mtu := iface.Mtu
 		if mtu != ifaceStatus.Mtu {
-			glog.V(2).Infof("needUpdate(): MTU needs update, desired=%d, current=%d", mtu, ifaceStatus.Mtu)
+			glog.V(2).Infof("NeedUpdate(): MTU needs update, desired=%d, current=%d", mtu, ifaceStatus.Mtu)
 			return true
 		}
 	}
 
 	if iface.NumVfs != ifaceStatus.NumVfs {
-		glog.V(2).Infof("needUpdate(): NumVfs needs update desired=%d, current=%d", iface.NumVfs, ifaceStatus.NumVfs)
+		glog.V(2).Infof("NeedUpdate(): NumVfs needs update desired=%d, current=%d", iface.NumVfs, ifaceStatus.NumVfs)
 		return true
 	}
 	if iface.NumVfs > 0 {
@@ -220,16 +220,16 @@ func needUpdate(iface *sriovnetworkv1.Interface, ifaceStatus *sriovnetworkv1.Int
 					ingroup = true
 					if group.DeviceType != constants.DeviceTypeNetDevice {
 						if group.DeviceType != vf.Driver {
-							glog.V(2).Infof("needUpdate(): Driver needs update, desired=%s, current=%s", group.DeviceType, vf.Driver)
+							glog.V(2).Infof("NeedUpdate(): Driver needs update, desired=%s, current=%s", group.DeviceType, vf.Driver)
 							return true
 						}
 					} else {
 						if sriovnetworkv1.StringInArray(vf.Driver, DpdkDrivers) {
-							glog.V(2).Infof("needUpdate(): Driver needs update, desired=%s, current=%s", group.DeviceType, vf.Driver)
+							glog.V(2).Infof("NeedUpdate(): Driver needs update, desired=%s, current=%s", group.DeviceType, vf.Driver)
 							return true
 						}
-						if vf.Mtu != 0 && vf.Mtu != group.Mtu {
-							glog.V(2).Infof("needUpdate(): VF %d MTU needs update, desired=%d", vf.VfID, group.Mtu)
+						if vf.Mtu != 0 && group.Mtu != 0 && vf.Mtu != group.Mtu {
+							glog.V(2).Infof("NeedUpdate(): VF %d MTU needs update, desired=%d, current=%d", vf.VfID, group.Mtu, vf.Mtu)
 							return true
 						}
 					}

--- a/pkg/utils/utils_mlx.go
+++ b/pkg/utils/utils_mlx.go
@@ -1,0 +1,117 @@
+package utils
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+//BlueField mode representation
+type BlueFieldMode int
+
+const (
+	bluefieldDpu BlueFieldMode = iota
+	bluefieldConnectXMode
+
+	internalCPUPageSupplier   = "INTERNAL_CPU_PAGE_SUPPLIER"
+	internalCPUEswitchManager = "INTERNAL_CPU_ESWITCH_MANAGER"
+	internalCPUIbVporto       = "INTERNAL_CPU_IB_VPORT0"
+	internalCPUOffloadEngine  = "INTERNAL_CPU_OFFLOAD_ENGINE"
+	internalCPUModel          = "INTERNAL_CPU_MODEL"
+
+	ecpf        = "ECPF"
+	extHostPf   = "EXT_HOST_PF"
+	embeddedCPU = "EMBEDDED_CPU"
+
+	disabled = "DISABLED"
+	enabled  = "ENABLED"
+)
+
+func MstConfigReadData(pciAddress string) (string, error) {
+	glog.Infof("MstConfigReadData(): device %s", pciAddress)
+	args := []string{"-e", "-d", pciAddress, "q"}
+	out, err := RunCommand("mstconfig", args...)
+	return out, err
+}
+
+func ParseMstconfigOutput(mstOutput string, attributes []string) (fwCurrent, fwNext map[string]string) {
+	glog.Infof("ParseMstconfigOutput(): Attributes %v", attributes)
+	fwCurrent = map[string]string{}
+	fwNext = map[string]string{}
+	formatRegex := regexp.MustCompile(`(?P<Attribute>\w+)\s+(?P<Default>\S+)\s+(?P<Current>\S+)\s+(?P<Next>\S+)`)
+	mstOutputLines := strings.Split(mstOutput, "\n")
+	for _, attr := range attributes {
+		for _, line := range mstOutputLines {
+			if strings.Contains(line, attr) {
+				regexResult := formatRegex.FindStringSubmatch(line)
+				fwCurrent[attr] = regexResult[3]
+				fwNext[attr] = regexResult[4]
+				break
+			}
+		}
+	}
+	return
+}
+
+func mellanoxBlueFieldMode(PciAddress string) (BlueFieldMode, error) {
+	glog.V(2).Infof("MellanoxBlueFieldMode():checking mode for card %s", PciAddress)
+	out, err := MstConfigReadData(PciAddress)
+	if err != nil {
+		glog.Errorf("MellanoxBlueFieldMode(): failed to get mlx nic fw data %v", err)
+		return -1, fmt.Errorf("failed to get mlx nic fw data %v", err)
+	}
+
+	attrs := []string{internalCPUPageSupplier,
+		internalCPUEswitchManager,
+		internalCPUIbVporto,
+		internalCPUOffloadEngine,
+		internalCPUModel}
+	mstCurrentData, _ := ParseMstconfigOutput(out, attrs)
+
+	internalCPUPageSupplierstatus, exist := mstCurrentData[internalCPUPageSupplier]
+	if !exist {
+		return 0, fmt.Errorf("failed to find %s in the mstconfig output command", internalCPUPageSupplier)
+	}
+
+	internalCPUEswitchManagerStatus, exist := mstCurrentData[internalCPUEswitchManager]
+	if !exist {
+		return 0, fmt.Errorf("failed to find %s in the mstconfig output command", internalCPUEswitchManager)
+	}
+
+	internalCPUIbVportoStatus, exist := mstCurrentData[internalCPUIbVporto]
+	if !exist {
+		return 0, fmt.Errorf("failed to find %s in the mstconfig output command", internalCPUIbVporto)
+	}
+
+	internalCPUOffloadEngineStatus, exist := mstCurrentData[internalCPUOffloadEngine]
+	if !exist {
+		return 0, fmt.Errorf("failed to find %s in the mstconfig output command", internalCPUOffloadEngine)
+	}
+
+	internalCPUModelStatus, exist := mstCurrentData[internalCPUModel]
+	if !exist {
+		return 0, fmt.Errorf("failed to find %s in the mstconfig output command", internalCPUModel)
+	}
+
+	// check for DPU
+	if strings.Contains(internalCPUPageSupplierstatus, ecpf) &&
+		strings.Contains(internalCPUEswitchManagerStatus, ecpf) &&
+		strings.Contains(internalCPUIbVportoStatus, ecpf) &&
+		strings.Contains(internalCPUOffloadEngineStatus, enabled) &&
+		strings.Contains(internalCPUModelStatus, embeddedCPU) {
+		glog.V(2).Infof("MellanoxBlueFieldMode():card %s in DPU mode", PciAddress)
+		return bluefieldDpu, nil
+	} else if strings.Contains(internalCPUPageSupplierstatus, extHostPf) &&
+		strings.Contains(internalCPUEswitchManagerStatus, extHostPf) &&
+		strings.Contains(internalCPUIbVportoStatus, extHostPf) &&
+		strings.Contains(internalCPUOffloadEngineStatus, disabled) &&
+		strings.Contains(internalCPUModelStatus, embeddedCPU) {
+		glog.V(2).Infof("MellanoxBlueFieldMode():card %s in ConnectX mode", PciAddress)
+		return bluefieldConnectXMode, nil
+	}
+
+	glog.Errorf("MellanoxBlueFieldMode(): unknown card status for %s mstconfig output \n %s", PciAddress, out)
+	return -1, fmt.Errorf("MellanoxBlueFieldMode(): unknown card status for %s", PciAddress)
+}


### PR DESCRIPTION
Gather commits using

```
$ git --no-pager log --cherry-pick --format="%h %s" --left-only --no-merges upstream/master...openshift/master
42eb7e94 Fix the issue introduced in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/240/files#r808624002
34b3fc31 move mellanox mstconfig functions to the utils_mlx.go
3a2ee559 update yaml configuration to allow for control plane status detection
64a59431 add automation path for components to operate in a hypershift environment (without mco)
9ca96bc9 add openshift context struct for openshift specific metadata
6cdb4827 improve drain check
61a08207 Adding suport for Octeon DPU family
c3fd5f64 update openshift-api to include external control plane topology enum
711302e0 support external control plane

c5c69732 lint: fix goconst issues
...

$ git cherry-pick 711302e0 c3fd5f64 61a08207 6cdb4827 9ca96bc9 64a59431 3a2ee559 34b3fc31 42eb7e94
```

/cc @SchSeba 
