### PR TITLE
OCPBUGS-2109: Sync 2022 10

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -21,6 +21,7 @@ data:
   Nvidia_mlx5_ConnectX-6: "15b3 101b 101c"
   Nvidia_mlx5_ConnectX-6_Dx: "15b3 101d 101e"
   Nvidia_mlx5_ConnectX-6_Lx: "15b3 101f 101e"
+  Nvidia_mlx5_ConnectX-7: "15b3 1021 101e"
   Nvidia_mlx5_MT42822_BlueField-2_integrated_ConnectX-6_Dx: "15b3 a2d6 101e"
   Broadcom_bnxt_BCM57414_2x25G: "14e4 16d7 16dc"
   Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"

--- a/deployment/sriov-network-operator/templates/configmap.yaml
+++ b/deployment/sriov-network-operator/templates/configmap.yaml
@@ -21,6 +21,7 @@ data:
   Nvidia_mlx5_ConnectX-6: "15b3 101b 101c"
   Nvidia_mlx5_ConnectX-6_Dx: "15b3 101d 101e"
   Nvidia_mlx5_ConnectX-6_Lx: "15b3 101f 101e"
+  Nvidia_mlx5_ConnectX-7: "15b3 1021 101e"
   Nvidia_mlx5_MT42822_BlueField-2_integrated_ConnectX-6_Dx: "15b3 a2d6 101e"
   Broadcom_bnxt_BCM57414_2x25G: "14e4 16d7 16dc"
   Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"

--- a/doc/supported-hardware.md
+++ b/doc/supported-hardware.md
@@ -17,6 +17,7 @@ The following SR-IOV capable hardware is supported with sriov-network-operator:
 | Mellanox MT28908 Family [ConnectX-6] | 15b3 | 101b |
 | Mellanox MT28908 Family [ConnectX-6 Dx] | 15b3 | 101d |
 | Mellanox MT28908 Family [ConnectX-6 Lx] | 15b3 | 101f |
+| Mellanox MT2910 Family [ConnectX-7 | 15b3 | 1021 |
 | Mellanox MT42822 BlueField-2 integrated ConnectX-6 Dx | 15b3 | a2d6 |
 | Qlogic QL45000 Series 50GbE Controller | 1077 | 1654 |
 | Marvell OCTEON TX2 CN96XX | 177d | b200 |
@@ -51,6 +52,7 @@ The following table depicts the supported SR-IOV hardware features of each suppo
 | Mellanox MT28908 Family [ConnectX-6] | V | V | V |
 | Mellanox MT28908 Family [ConnectX-6 Dx] | V | V | V |
 | Mellanox MT28908 Family [ConnectX-6 Lx] | V | V | V |
+| Mellanox MT28908 Family [ConnectX-7] | V | V | V |
 | Mellanox MT42822 BlueField-2 integrated ConnectX-6 Dx | V | V | V |
 | Qlogic QL45000 Series 50GbE Controller | V | X | X |
 | Marvell OCTEON TX2 CN96XX | V | V | X |

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1026,8 +1026,8 @@ func tryCreateSwitchdevUdevRule(nodeState *sriovnetworkv1.SriovNetworkNodeState)
 
 func tryCreateNMUdevRule() error {
 	glog.V(2).Infof("tryCreateNMUdevRule()")
-	dirPath := path.Join(filesystemRoot, "/host/etc/udev/rules.d/")
-	filePath := dirPath + "10-nm-unmanaged.rules"
+	dirPath := path.Join(filesystemRoot, "/host/etc/udev/rules.d")
+	filePath := path.Join(dirPath, "10-nm-unmanaged.rules")
 
 	newContent := fmt.Sprintf("ACTION==\"add|change|move\", ATTRS{device}==\"%s\", ENV{NM_UNMANAGED}=\"1\"\n", strings.Join(sriovnetworkv1.GetSupportedVfIds(), "|"))
 


### PR DESCRIPTION
```
$ git --no-pager log --cherry-pick --format="%h %s" --left-only --no-merges upstream/master...openshift/master                                                                                                                   
1c0bf417 daemon: fix NM udev path
c7c06b1a Add SIGTERM flag to avoid flaky updates
431e210f Add terminationGracefulPeriodSeconds to config daemonset
38755ee8 Remove unused dependencies
454c4d28 Add graceful node shutdown support to config daemon

# empty commit
3a2ee559 update yaml configuration to allow for control plane status detection

# Blank line 
6cdb4827 improve drain check

20fce6cb Add NVIDIA ConnectX-7 to supported NICs

# Already cherry picked
61a08207 Adding suport for Octeon DPU family

$ git cherry-pick 20fce6cb 454c4d28 38755ee8 431e210f c7c06b1a 1c0bf417
```

/cc @pacevedom 