### PR TITLE
OCPBUGS-2126: Update RBAC files for the network-config-daemon

### DIFF
--- a/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
@@ -222,6 +222,14 @@ spec:
           - '*'
           verbs:
           - '*'
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - infrastructures
+          verbs:
+          - get
+          - list
+          - watch
         serviceAccountName: sriov-network-config-daemon
       - rules:
         - apiGroups:

--- a/config/rbac/sriov-network-config-daemon_clusterrole.yaml
+++ b/config/rbac/sriov-network-config-daemon_clusterrole.yaml
@@ -18,3 +18,6 @@ rules:
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["*"]
   verbs: ["*"]
+- apiGroups: ["config.openshift.io"]
+  resources: ["infrastructures"]
+  verbs: ["get", "list", "watch"]

--- a/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
+++ b/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
@@ -222,6 +222,14 @@ spec:
           - '*'
           verbs:
           - '*'
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - infrastructures
+          verbs:
+          - get
+          - list
+          - watch
         serviceAccountName: sriov-network-config-daemon
       - rules:
         - apiGroups:


### PR DESCRIPTION
The network-config-daemon needs access to the resource "infrastructures" in the API group "config.openshift.io".

This resource is needed for allowing control plane status detection. This was updated upstream in commit:
"update yaml configuration to allow for control plane status detection" a13b59e7f8f74d

Also ran "make bundle" to update the manifest files.