### PR TITLE
End2End - Pod Security Admission fixes

### DIFF
--- a/test/util/clean/clean.go
+++ b/test/util/clean/clean.go
@@ -26,9 +26,7 @@ func All() error {
 			return fmt.Errorf("failed to restore node drain state %v", err)
 		}
 	}
-	if !namespaces.Exists(namespaces.Test, clients) {
-		return nil
-	}
+
 	err := namespaces.DeleteAndWait(clients, namespaces.Test, 5*time.Minute)
 	if err != nil {
 		return fmt.Errorf("failed to delete sriov tests namespace %v", err)

--- a/test/util/namespaces/namespaces.go
+++ b/test/util/namespaces/namespaces.go
@@ -20,6 +20,13 @@ import (
 // Test is the namespace to be use for testing
 const Test = "sriov-conformance-testing"
 
+var inhibitSecurityAdmissionLabels = map[string]string{
+	"pod-security.kubernetes.io/audit":               "privileged",
+	"pod-security.kubernetes.io/enforce":             "privileged",
+	"pod-security.kubernetes.io/warn":                "privileged",
+	"security.openshift.io/scc.podSecurityLabelSync": "false",
+}
+
 // WaitForDeletion waits until the namespace will be removed from the cluster
 func WaitForDeletion(cs *testclient.ClientSet, nsName string, timeout time.Duration) error {
 	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
@@ -36,7 +43,8 @@ func WaitForDeletion(cs *testclient.ClientSet, nsName string, timeout time.Durat
 func Create(namespace string, cs *testclient.ClientSet) error {
 	_, err := cs.Namespaces().Create(context.Background(), &k8sv1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
+			Name:   namespace,
+			Labels: inhibitSecurityAdmissionLabels,
 		}}, metav1.CreateOptions{})
 
 	if k8serrors.IsAlreadyExists(err) {

--- a/test/util/namespaces/namespaces.go
+++ b/test/util/namespaces/namespaces.go
@@ -45,12 +45,17 @@ func Create(namespace string, cs *testclient.ClientSet) error {
 	return err
 }
 
-// DeleteAndWait deletes a namespace and waits until delete
+// DeleteAndWait deletes a namespace and waits until it is deleted
 func DeleteAndWait(cs *testclient.ClientSet, namespace string, timeout time.Duration) error {
 	err := cs.Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{})
-	if err != nil {
-		return err
+	if k8serrors.IsNotFound(err) {
+		return nil
 	}
+
+	if err != nil {
+		return fmt.Errorf("failed to delete namespace [%s]: %w", namespace, err)
+	}
+
 	return WaitForDeletion(cs, namespace, timeout)
 }
 


### PR DESCRIPTION
Sync of https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/368

These changes aim to solve [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) problem when running tests against k8s v1.25+ , as privileged pods are often needed during tests.