### PR TITLE
fix naming convention

### DIFF
--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -3,7 +3,7 @@ updates:
     update_list:
     # replace metadata.name value
     - search: "sriov-network-operator.v{MAJOR}.{MINOR}.0"
-      replace: "sriov-network-operator.{FULL_VER}"
+      replace: "sriov-network-operator.v{FULL_VER}"
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"
     - search: "olm.skipRange: '>=4.3.0-0 <{MAJOR}.{MINOR}.0'"


### PR DESCRIPTION
there is a warning reported in CVP check for 4.12
`Warning: Value : (sriov-network-operator.4.12.0-202211181156) csv.metadata.Name sriov-network-operator.4.12.0-202211181156 is not following the recommended naming convention: <operator-name>.v<semver> e.g. memcached-operator.v0.0.1`
http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/sriov-network-operator-metadata-container-v4.12.0.202211181156.p0.gb97559f.assembly.stream-1/35398f20-d276-4e44-92fd-9da1b5f48bb3/operator-metadata-linting-bundle-image-output.txt
I think this could be a common issue, so pr against master can cherry-pick to 4.12 branch later.