### PR TITLE
OCPBUGS-4626: Fix machine config update in sriovnetworkpoolconfig_controller

### DIFF
--- a/controllers/sriovnetworkpoolconfig_controller.go
+++ b/controllers/sriovnetworkpoolconfig_controller.go
@@ -1,9 +1,10 @@
 package controllers
 
 import (
-	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -175,14 +176,24 @@ func (r *SriovNetworkPoolConfigReconciler) syncOvsHardwareOffloadMachineConfigs(
 				return fmt.Errorf("couldn't delete MachineConfig: %v", err)
 			}
 		} else {
-			if bytes.Equal(foundMC.Spec.Config.Raw, mc.Spec.Config.Raw) {
+			var foundIgn, renderedIgn interface{}
+			// The Raw config JSON string may have the fields reordered.
+			// For example the "path" field may come before the "contents"
+			// field in the rendered ignition JSON; while the found
+			// MachineConfig's ignition JSON would have it the other way around.
+			// Thus we need to unmarshal the JSON for both found and rendered
+			// ignition and compare.
+			json.Unmarshal(foundMC.Spec.Config.Raw, &foundIgn)
+			json.Unmarshal(mc.Spec.Config.Raw, &renderedIgn)
+			if !reflect.DeepEqual(foundIgn, renderedIgn) {
 				logger.Info("MachineConfig already exists, updating")
-				err = r.Update(context.TODO(), foundMC)
+				mc.SetResourceVersion(foundMC.GetResourceVersion())
+				err = r.Update(context.TODO(), mc)
 				if err != nil {
 					return fmt.Errorf("couldn't update MachineConfig: %v", err)
 				}
 			} else {
-				logger.Info("No content change, skip updating MC")
+				logger.Info("No content change, skip updating MachineConfig")
 			}
 		}
 	}


### PR DESCRIPTION
These fixes only apply to Openshift clusters with the machine config operator.

The controller was not detecting changes to the machine config files. Firstly if the existing MachineConfig's ignition JSON differs from the rendered MachineConfig's ignition JSON then we should update the MachineConfig. Then we should update the MachineConfig with the rendered MachineConfig. This logic had an incorrect implementation priorly.

(cherry picked from commit 45257c4ff61285cf3c153ce3df4b7a617fa0358d)