### PR TITLE
OCPBUGS-11170: Fix drain logic after node reboot

### DIFF
--- a/pkg/plugins/generic/generic_plugin.go
+++ b/pkg/plugins/generic/generic_plugin.go
@@ -164,28 +164,31 @@ func isCommandNotFound(err error) bool {
 }
 
 func needDrainNode(desired sriovnetworkv1.Interfaces, current sriovnetworkv1.InterfaceExts) (needDrain bool) {
+	glog.V(2).Infof("generic-plugin needDrainNode(): current state '%+v', desired state '%+v'", current, desired)
 	needDrain = false
 	for _, ifaceStatus := range current {
 		configured := false
 		for _, iface := range desired {
 			if iface.PciAddress == ifaceStatus.PciAddress {
+				// TODO: no need to perform further checks if ifaceStatus.NumVfs equals to 0
+				// once https://github.com/kubernetes/kubernetes/issues/109595 will be fixed
 				configured = true
+
 				if iface.EswitchMode == sriovnetworkv1.ESWITCHMODE_SWITCHDEV {
 					// ignore swichdev device
 					break
 				}
-				if ifaceStatus.NumVfs != 0 {
-					if iface.NumVfs != ifaceStatus.NumVfs {
-						glog.V(2).Infof("generic-plugin needDrainNode(): need drain, expect NumVfs %v, current NumVfs %v", iface.NumVfs, ifaceStatus.NumVfs)
-						needDrain = true
-						return
-					}
-					if iface.Mtu != 0 && iface.Mtu != ifaceStatus.Mtu {
-						glog.V(2).Infof("generic-plugin needDrainNode(): need drain, expect MTU %v, current MTU %v", iface.Mtu, ifaceStatus.Mtu)
-						needDrain = true
-						return
-					}
+				if iface.NumVfs != ifaceStatus.NumVfs {
+					glog.V(2).Infof("generic-plugin needDrainNode(): need drain, expect NumVfs %v, current NumVfs %v", iface.NumVfs, ifaceStatus.NumVfs)
+					needDrain = true
+					return
 				}
+				if iface.Mtu != 0 && iface.Mtu != ifaceStatus.Mtu {
+					glog.V(2).Infof("generic-plugin needDrainNode(): need drain, expect MTU %v, current MTU %v", iface.Mtu, ifaceStatus.Mtu)
+					needDrain = true
+					return
+				}
+				glog.V(2).Infof("generic-plugin needDrainNode(): no need drain, expect NumVfs %v, current NumVfs %v", iface.NumVfs, ifaceStatus.NumVfs)
 			}
 		}
 		if !configured && ifaceStatus.NumVfs > 0 {


### PR DESCRIPTION
Backport 'Fix drain logic after node reboot'[1]

After rebooting a node, CNI call to re-establish the secondary interface on a workload pod fails. Draining the node fixes this issue.

Fixes: [OCPBUGS-11170](https://issues.redhat.com/browse/OCPBUGS-11170)

[1] https://github.com/e0ne/sriov-network-operator/commit/5796b5d77b8efb8a2e6f1e209ffc27d3f1922063