### PR TITLE
[release-4.10] OCPBUGS-14360: Continue node drain after reboot

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -559,9 +559,11 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 			return err
 		}
 	} else {
-		if err := dn.annotateNode(dn.name, annoIdle); err != nil {
-			glog.Errorf("nodeStateSyncHandler(): failed to annotate node: %v", err)
-			return err
+		if !dn.nodeHasAnnotation(annoKey, annoIdle) {
+			if err := dn.annotateNode(dn.name, annoIdle); err != nil {
+				glog.Errorf("nodeStateSyncHandler(): failed to annotate node: %v", err)
+				return err
+			}
 		}
 	}
 	glog.Info("nodeStateSyncHandler(): sync succeeded")
@@ -573,6 +575,14 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 	// wait for writer to refresh the status
 	<-dn.syncCh
 	return nil
+}
+
+func (dn *Daemon) nodeHasAnnotation(annoKey string, value string) bool {
+	// Check if node already contains annotation
+	if anno, ok := dn.node.Annotations[annoKey]; ok && (anno == value) {
+		return true
+	}
+	return false
 }
 
 func (dn *Daemon) isNodeDraining() bool {


### PR DESCRIPTION
Backport the following commits:
- 'Continue node drain after reboot' d48291194e861bcbcb575b9884d6a0a7a615d461
- 'Annotate node only if there is no existing annotation' 008d2fe669e8922f783b43c490d7a5820bc55daa

After a node reboot, the number of VFs would be zero, then `reqDrain` would be set and we will need to drain also after a reboot. This behavior is caused by this
commit backport  https://github.com/openshift/sriov-network-operator/commit/7d099d32f3a38e89a56f73807ce60aa26b35cef4 . This will cause the drain lock to be attempted to be taken again. However a deadlock would occur if another node already took the lock at the same time. The  'Continue node drain after reboot' commit solves this issue by checking if we have the drain node annotation which means we are safe to proceed draining without taking the lock.