### PR TITLE
[release-4.9] OCPBUGS-14582: Continue node drain after reboot

### DIFF
--- a/controllers/sriovoperatorconfig_controller.go
+++ b/controllers/sriovoperatorconfig_controller.go
@@ -78,6 +78,11 @@ func (r *SriovOperatorConfigReconciler) Reconcile(ctx context.Context, req ctrl.
 		Name: constants.DEFAULT_CONFIG_NAME, Namespace: namespace}, defaultConfig)
 	if err != nil {
 		if errors.IsNotFound(err) {
+			singleNode, err := utils.IsSingleNodeCluster(r.Client)
+			if err != nil {
+				return reconcile.Result{}, fmt.Errorf("Couldn't check the anount of nodes in the cluster")
+			}
+
 			// Default Config object not found, create it.
 			defaultConfig.SetNamespace(namespace)
 			defaultConfig.SetName(constants.DEFAULT_CONFIG_NAME)
@@ -86,7 +91,9 @@ func (r *SriovOperatorConfigReconciler) Reconcile(ctx context.Context, req ctrl.
 				EnableOperatorWebhook:    func() *bool { b := enableAdmissionController; return &b }(),
 				ConfigDaemonNodeSelector: map[string]string{},
 				LogLevel:                 2,
+				DisableDrain:             singleNode,
 			}
+
 			err = r.Create(context.TODO(), defaultConfig)
 			if err != nil {
 				logger.Error(err, "Failed to create default Operator Config", "Namespace",

--- a/main.go
+++ b/main.go
@@ -232,6 +232,12 @@ func createDefaultOperatorConfig(cfg *rest.Config) error {
 	if err != nil {
 		return fmt.Errorf("Couldn't create client: %v", err)
 	}
+
+	singleNode, err := utils.IsSingleNodeCluster(c)
+	if err != nil {
+		return fmt.Errorf("Couldn't check the anount of nodes in the cluster")
+	}
+
 	enableAdmissionController := os.Getenv("ENABLE_ADMISSION_CONTROLLER") == "true"
 	config := &sriovnetworkv1.SriovOperatorConfig{
 		Spec: sriovnetworkv1.SriovOperatorConfigSpec{
@@ -239,6 +245,7 @@ func createDefaultOperatorConfig(cfg *rest.Config) error {
 			EnableOperatorWebhook:    func() *bool { b := enableAdmissionController; return &b }(),
 			ConfigDaemonNodeSelector: map[string]string{},
 			LogLevel:                 2,
+			DisableDrain:             singleNode,
 		},
 	}
 	name := "default"

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -498,24 +498,26 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 	}
 
 	if reqDrain {
-		ctx, cancel := context.WithCancel(context.TODO())
-		defer cancel()
+		if !dn.disableDrain {
+			ctx, cancel := context.WithCancel(context.TODO())
+			defer cancel()
 
-		glog.Infof("nodeStateSyncHandler(): get drain lock for sriov daemon")
-		done := make(chan bool)
-		go dn.getDrainLock(ctx, done)
-		<-done
-
-		glog.Infof("nodeStateSyncHandler(): pause MCP")
-		if err := dn.pauseMCP(); err != nil {
-			return err
+			glog.Infof("nodeStateSyncHandler(): get drain lock for sriov daemon")
+			done := make(chan bool)
+			go dn.getDrainLock(ctx, done)
+			<-done
 		}
 
-		if !dn.disableDrain {
-			glog.Info("nodeStateSyncHandler(): drain node")
-			if err := dn.drainNode(); err != nil {
+		if utils.ClusterType == utils.ClusterTypeOpenshift {
+			glog.Infof("nodeStateSyncHandler(): pause MCP")
+			if err := dn.pauseMCP(); err != nil {
 				return err
 			}
+		}
+
+		glog.Info("nodeStateSyncHandler(): drain node")
+		if err := dn.drainNode(); err != nil {
+			return err
 		}
 	}
 
@@ -822,13 +824,8 @@ func (dn *Daemon) getDrainLock(ctx context.Context, done chan bool) {
 }
 
 func (dn *Daemon) pauseMCP() error {
-	glog.Info("pauseMCP(): check if pausing MCP is possible")
+	glog.Info("pauseMCP(): pausing MCP")
 	var err error
-
-	if utils.ClusterType != utils.ClusterTypeOpenshift {
-		glog.Infof("pauseMCP(): skipping MCP pause as the cluster is not an openshift cluster")
-		return nil
-	}
 
 	mcpInformerFactory := mcfginformers.NewSharedInformerFactory(dn.mcClient,
 		time.Second*30,
@@ -916,6 +913,11 @@ func (dn *Daemon) pauseMCP() error {
 }
 
 func (dn *Daemon) drainNode() error {
+	if dn.disableDrain {
+		glog.Info("drainNode(): disable drain is true skipping drain")
+		return nil
+	}
+
 	glog.Info("drainNode(): Update prepared")
 	var err error
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -540,14 +540,11 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 	}
 
 	// restart device plugin pod
-	if reqDrain || latestState.Spec.DpConfigVersion != dn.nodeState.Spec.DpConfigVersion {
-		glog.Info("nodeStateSyncHandler(): restart device plugin pod")
-		if err := dn.restartDevicePluginPod(); err != nil {
-			glog.Errorf("nodeStateSyncHandler(): fail to restart device plugin pod: %v", err)
-			return err
-		}
+	glog.Info("nodeStateSyncHandler(): restart device plugin pod")
+	if err := dn.restartDevicePluginPod(); err != nil {
+		glog.Errorf("nodeStateSyncHandler(): fail to restart device plugin pod: %v", err)
+		return err
 	}
-
 	if anno, ok := dn.node.Annotations[annoKey]; ok && (anno == annoDraining || anno == annoMcpPaused) {
 		if err := dn.completeDrain(); err != nil {
 			glog.Errorf("nodeStateSyncHandler(): failed to complete draining: %v", err)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -498,20 +498,23 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 	}
 
 	if reqDrain {
-		if !dn.disableDrain {
-			ctx, cancel := context.WithCancel(context.TODO())
-			defer cancel()
+		if !dn.isNodeDraining() {
+			if !dn.disableDrain {
+				ctx, cancel := context.WithCancel(context.TODO())
+				defer cancel()
 
-			glog.Infof("nodeStateSyncHandler(): get drain lock for sriov daemon")
-			done := make(chan bool)
-			go dn.getDrainLock(ctx, done)
-			<-done
-		}
+				glog.Infof("nodeStateSyncHandler(): get drain lock for sriov daemon")
+				done := make(chan bool)
+				go dn.getDrainLock(ctx, done)
+				<-done
 
-		if utils.ClusterType == utils.ClusterTypeOpenshift {
-			glog.Infof("nodeStateSyncHandler(): pause MCP")
-			if err := dn.pauseMCP(); err != nil {
-				return err
+			}
+
+			if utils.ClusterType == utils.ClusterTypeOpenshift {
+				glog.Infof("nodeStateSyncHandler(): pause MCP")
+				if err := dn.pauseMCP(); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -545,12 +548,12 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 		glog.Errorf("nodeStateSyncHandler(): fail to restart device plugin pod: %v", err)
 		return err
 	}
-	if anno, ok := dn.node.Annotations[annoKey]; ok && (anno == annoDraining || anno == annoMcpPaused) {
+	if dn.isNodeDraining() {
 		if err := dn.completeDrain(); err != nil {
 			glog.Errorf("nodeStateSyncHandler(): failed to complete draining: %v", err)
 			return err
 		}
-	} else if !ok {
+	} else {
 		if err := dn.annotateNode(dn.name, annoIdle); err != nil {
 			glog.Errorf("nodeStateSyncHandler(): failed to annotate node: %v", err)
 			return err
@@ -565,6 +568,13 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 	// wait for writer to refresh the status
 	<-dn.syncCh
 	return nil
+}
+
+func (dn *Daemon) isNodeDraining() bool {
+	if anno, ok := dn.node.Annotations[annoKey]; ok && (anno == annoDraining || anno == annoMcpPaused) {
+		return true
+	}
+	return false
 }
 
 func (dn *Daemon) completeDrain() error {
@@ -810,7 +820,7 @@ func (dn *Daemon) getDrainLock(ctx context.Context, done chan bool) {
 						done <- true
 						return
 					}
-					glog.V(3).Info("getDrainLock(): other node is draining, wait...")
+					glog.V(2).Info("getDrainLock(): other node is draining, wait...")
 				}
 			},
 			OnStoppedLeading: func() {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -554,9 +554,11 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 			return err
 		}
 	} else {
-		if err := dn.annotateNode(dn.name, annoIdle); err != nil {
-			glog.Errorf("nodeStateSyncHandler(): failed to annotate node: %v", err)
-			return err
+		if !dn.nodeHasAnnotation(annoKey, annoIdle) {
+			if err := dn.annotateNode(dn.name, annoIdle); err != nil {
+				glog.Errorf("nodeStateSyncHandler(): failed to annotate node: %v", err)
+				return err
+			}
 		}
 	}
 	glog.Info("nodeStateSyncHandler(): sync succeeded")
@@ -568,6 +570,14 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 	// wait for writer to refresh the status
 	<-dn.syncCh
 	return nil
+}
+
+func (dn *Daemon) nodeHasAnnotation(annoKey string, value string) bool {
+	// Check if node already contains annotation
+	if anno, ok := dn.node.Annotations[annoKey]; ok && (anno == value) {
+		return true
+	}
+	return false
 }
 
 func (dn *Daemon) isNodeDraining() bool {

--- a/pkg/utils/cluster.go
+++ b/pkg/utils/cluster.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/golang/glog"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func IsSingleNodeCluster(c client.Client) (bool, error) {
+	nodeList := &corev1.NodeList{}
+	err := c.List(context.TODO(), nodeList)
+	if err != nil {
+		glog.Errorf("IsSingleNodeCluster(): Failed to list nodes: %v", err)
+		return false, err
+	}
+
+	if len(nodeList.Items) == 1 {
+		glog.Infof("IsSingleNodeCluster(): one node found in the cluster")
+		return true, nil
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
Backport the following commits:
- 'Continue node drain after reboot' d48291194e861bcbcb575b9884d6a0a7a615d461
- 'Annotate node only if there is no existing annotation' 008d2fe669e8922f783b43c490d7a5820bc55daa

However missing these commits for clean cherry-pick:
- 'Add the DisableDrain when running one a single node' a4910597cdd782578dba992a6ef64d0b53c7c9a2
- 'Always restart device plugin pod' 4ebf517aa50f3fc7da21849641fe354e78545273

From: 
https://github.com/openshift/sriov-network-operator/pull/610
https://github.com/openshift/sriov-network-operator/pull/570

After a node reboot, the number of VFs would be zero, then `reqDrain` would be set and we will need to drain also after a reboot. This behavior is caused by this
commit backport  https://github.com/openshift/sriov-network-operator/commit/7d099d32f3a38e89a56f73807ce60aa26b35cef4 . This will cause the drain lock to be attempted to be taken again. However a deadlock would occur if another node already took the lock at the same time. The  'Continue node drain after reboot' commit solves this issue by checking if we have the drain node annotation which means we are safe to proceed draining without taking the lock.