### PR TITLE
OCPBUGS-14954: Fix multiple dev bug 4.13

### DIFF
--- a/bindata/scripts/bf2-switch-mode.sh
+++ b/bindata/scripts/bf2-switch-mode.sh
@@ -11,26 +11,32 @@
 set -e
 
 mode=${1:-query}
-device=${2:-"$(mstconfig q | grep "Device:" | awk 'BEGIN {FS="/";} { print $6 }')"}
+devices=${2:-"$(mstconfig q | grep "Device:" | awk 'BEGIN {FS="/";} { print $6 }')"}
 
-if [ -z "$device" ]; then
-    echo "Can't find device."
+for device in $devices; do
+    echo "Found device: $device"
+    type=$(mstconfig -d $device q | grep "Device type:" | awk '{ print $3}')
+
+    if [ "${type}" != "BlueField2" ]; then
+        echo "Device $device is not a Bluefield2"
+        devices=${devices/$device/}
+    fi
+done
+
+if [ -z "$devices" ]; then
+    echo "Can't find bluefield device."
     exit 120
 else
-    echo Found device: "${device}"
+    echo Configuring bluefield devices: "${devices}"
 fi
 
-type=$(mstconfig -d $device q | grep "Device type:" | awk '{ print $3}')
-
-if [ "${type}" != "BlueField2" ]; then
-    echo "Device is not a Bluefield2"
-    exit 120
-fi
+# In the event no reboot is required, return 120. If reboot is required, return 0
+ret=120
 
 fwreset () {
     mstfwreset -y -d "${device}" reset
     echo "Switched to ${mode} mode."
-    exit 0
+    ret=0
 }
 
 query () {
@@ -43,40 +49,44 @@ query () {
     echo "Current DPU configuration: ${current_config}"
 }
 
-query
-case "${mode}" in
-    dpu)
-        if [ "${current_config}" == "EMBEDDED_CPU(1) ECPF(0) ECPF(0) ECPF(0) ENABLED(0)" ]; then
-            echo "Already in DPU mode."
-        else
-            echo "Switching to DPU mode."
-            mstconfig -y -d "${device}" s \
-                INTERNAL_CPU_MODEL=EMBEDDED_CPU \
-                INTERNAL_CPU_PAGE_SUPPLIER=ECPF \
-                INTERNAL_CPU_ESWITCH_MANAGER=ECPF \
-                INTERNAL_CPU_IB_VPORT0=ECPF \
-                INTERNAL_CPU_OFFLOAD_ENGINE=ENABLED
-            fwreset
-        fi
-        ;;
-    nic)
-        if [ "${current_config}" == "EMBEDDED_CPU(1) EXT_HOST_PF(1) EXT_HOST_PF(1) EXT_HOST_PF(1) DISABLED(1)" ]; then
-            echo "Already in NIC mode."
-        else
-            echo "Switching to NIC mode."
-            mstconfig -y -d "${device}" s \
-                INTERNAL_CPU_MODEL=EMBEDDED_CPU \
-                INTERNAL_CPU_PAGE_SUPPLIER=EXT_HOST_PF \
-                INTERNAL_CPU_ESWITCH_MANAGER=EXT_HOST_PF \
-                INTERNAL_CPU_IB_VPORT0=EXT_HOST_PF \
-                INTERNAL_CPU_OFFLOAD_ENGINE=DISABLED
-            fwreset
-        fi
-        ;;
-    *)
-        echo "Invalid mode '${mode}', expecting 'nic' or 'dpu'"
-        ;;
-esac
+for device in $devices; do
 
-exit 120
+    query
+    case "${mode}" in
+        dpu)
+            if [ "${current_config}" == "EMBEDDED_CPU(1) ECPF(0) ECPF(0) ECPF(0) ENABLED(0)" ]; then
+                echo "${device} Already in DPU mode."
+            else
+                echo "Switching ${device} to DPU mode."
+                mstconfig -y -d "${device}" s \
+                    INTERNAL_CPU_MODEL=EMBEDDED_CPU \
+                    INTERNAL_CPU_PAGE_SUPPLIER=ECPF \
+                    INTERNAL_CPU_ESWITCH_MANAGER=ECPF \
+                    INTERNAL_CPU_IB_VPORT0=ECPF \
+                    INTERNAL_CPU_OFFLOAD_ENGINE=ENABLED
+                fwreset
+            fi
+            ;;
+        nic)
+            if [ "${current_config}" == "EMBEDDED_CPU(1) EXT_HOST_PF(1) EXT_HOST_PF(1) EXT_HOST_PF(1) DISABLED(1)" ]; then
+                echo "${device} Already in NIC mode."
+            else
+                echo "Switching ${device} to NIC mode."
+                mstconfig -y -d "${device}" s \
+                    INTERNAL_CPU_MODEL=EMBEDDED_CPU \
+                    INTERNAL_CPU_PAGE_SUPPLIER=EXT_HOST_PF \
+                    INTERNAL_CPU_ESWITCH_MANAGER=EXT_HOST_PF \
+                    INTERNAL_CPU_IB_VPORT0=EXT_HOST_PF \
+                    INTERNAL_CPU_OFFLOAD_ENGINE=DISABLED
+                fwreset
+            fi
+            ;;
+        *)
+            echo "Invalid mode '${mode}', expecting 'nic' or 'dpu'"
+            ;;
+    esac
+
+done
+
+exit $ret
 


### PR DESCRIPTION
Currently if multiple devices are detected, bf2-switch-mode will fail, and provide the misleading error "Can't find bluefield device".

Instead, check each device to verify if it is a Bluefield2, and if so, apply new configurations.