### PR TITLE
OCPBUGS-16247: [release-4.13] Fix race condition in leader election for OCP

### DIFF
--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -274,7 +274,7 @@ SUBSYSTEM=="net", ACTION=="add|move", ATTRS{phys_switch_id}!="", ATTR{phys_port_
 			Expect(sut.isNodeDraining()).To(BeFalse())
 
 			sut.node.Annotations["sriovnetwork.openshift.io/state"] = "Draining"
-			Expect(sut.isNodeDraining()).To(BeFalse())
+			Expect(sut.isNodeDraining()).To(BeTrue())
 
 			sut.node.Annotations["sriovnetwork.openshift.io/state"] = "Draining_MCP_Paused"
 			Expect(sut.isNodeDraining()).To(BeTrue())


### PR DESCRIPTION
In OCP we have two steps to prepare a node before we drain it. first we get leader election and annotate the node with Draining and then we pause the MCP and mark the node as MCP paused.

if the config_daemon get a reset between the fist part to the second it will get stuck because one node will take the leader election BUT it will not mark the node as Draining as there is another node already draining. and the node with the draining label will try to get the drain lock again but the first node has it.

with this change if the node as Draning or MCP pause label it will not try to take the lock again and just continue after the reset.