### PR TITLE
Partially revert BCM57504 update

### DIFF
--- a/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
@@ -100,7 +100,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/pliurh/sriov-network-operator-manager:bd1
-    createdAt: "2023-08-01T15:53:32Z"
+    createdAt: "2023-08-02T18:35:34Z"
     description: An operator for configuring SR-IOV components and initializing SRIOV
       network devices in Openshift cluster.
     olm.skipRange: '>=4.3.0-0 <4.14.0'

--- a/bundle/manifests/supported-nic-ids_v1_configmap.yaml
+++ b/bundle/manifests/supported-nic-ids_v1_configmap.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 data:
   Broadcom_bnxt_en_BCM57414_NetXtreme-E: 14e4 16d7 16c1
-  Broadcom_bnxt_en_BCM57504_NetXtreme-E: 14e4 1751 1806
   Broadcom_bnxt_en_BCM57508_NetXtreme-E: 14e4 1750 1806
   Intel_i40e_10G_X710_BACKPLANE: 8086 1581 154c
   Intel_i40e_10G_X710_BASE_T: 8086 15ff 154c

--- a/config/manifests/bases/sriov-network-operator_configmap.yaml
+++ b/config/manifests/bases/sriov-network-operator_configmap.yaml
@@ -5,7 +5,6 @@ metadata:
 data:
   Broadcom_bnxt_en_BCM57414_NetXtreme-E: "14e4 16d7 16c1"
   Broadcom_bnxt_en_BCM57508_NetXtreme-E: "14e4 1750 1806"
-  Broadcom_bnxt_en_BCM57504_NetXtreme-E: "14e4 1751 1806"
   Intel_i40e_XXV710: "8086 158a 154c"
   Intel_i40e_XXV710_25G: "8086 158b 154c"
   Intel_i40e_XL710_40G: "8086 1583 154c"

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -28,7 +28,6 @@ data:
   Nvidia_mlx5_MT43244_BlueField-3_integrated_ConnectX-7_Dx: "15b3 a2dc 101e"
   Broadcom_bnxt_BCM57414_2x25G: "14e4 16d7 16dc"
   Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"
-  Broadcom_bnxt_BCM57504_2x100G: "14e4 1751 1806"
   Qlogic_qede_QL45000_50G: "1077 1654 1664"
   Red_Hat_Virtio_network_device: "1af4 1000 1000"
   Marvell_OCTEON_TX2_CN96XX: "177d b200 b203"

--- a/deployment/sriov-network-operator/templates/configmap.yaml
+++ b/deployment/sriov-network-operator/templates/configmap.yaml
@@ -28,7 +28,6 @@ data:
   Nvidia_mlx5_MT43244_BlueField-3_integrated_ConnectX-7_Dx: "15b3 a2dc 101e"
   Broadcom_bnxt_BCM57414_2x25G: "14e4 16d7 16dc"
   Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"
-  Broadcom_bnxt_BCM57504_2x100G: "14e4 1751 1806"
   Qlogic_qede_QL45000_50G: "1077 1654 1664"
   Red_Hat_Virtio_network_device: "1af4 1000 1000"
   Marvell_OCTEON_TX2_CN96XX: "177d b200 b203"

--- a/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
+++ b/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
@@ -100,7 +100,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/pliurh/sriov-network-operator-manager:bd1
-    createdAt: "2023-08-01T15:53:32Z"
+    createdAt: "2023-08-02T18:35:34Z"
     description: An operator for configuring SR-IOV components and initializing SRIOV
       network devices in Openshift cluster.
     olm.skipRange: '>=4.3.0-0 <4.14.0'

--- a/pkg/webhook/validate_test.go
+++ b/pkg/webhook/validate_test.go
@@ -40,7 +40,6 @@ func TestMain(m *testing.M) {
 		"15b3 a2d6 101e", // MT42822 BlueField-2 integrated ConnectX-6 Dx
 		"14e4 16d7 16dc", // BCM57414 2x25G
 		"14e4 1750 1806", // BCM75508 2x100G
-		"14e4 1751 1806", // BCM57504 2x100G
 	}
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
https://github.com/openshift/sriov-network-operator/pull/808 added support for Broadcom BCM57504. Since no vendor from Broadcom is currently participating in maintaining support for this card upstream, this change has been made downstream only.

In order to avoid future merge conflicts with u/s, this change should be added in d/s only files. This commit reverts any changes to u/s config maps.