### PR TITLE
OCPBUGS-17929: Add support for BCM57504 Release 4.13

### DIFF
--- a/manifests/stable/supported-nic-ids_v1_configmap.yaml
+++ b/manifests/stable/supported-nic-ids_v1_configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 data:
   Broadcom_bnxt_en_BCM57414_NetXtreme-E: 14e4 16d7 16dc
   Broadcom_bnxt_en_BCM57508_NetXtreme-E: 14e4 1750 1806
+  Broadcom_bnxt_en_BCM57504_NetXtreme-E: 14e4 1751 1806
   Intel_i40e_X710_10G: 8086 1572 154c
   Intel_i40e_XL710_40G: 8086 1583 154c
   Intel_i40e_XXV710: 8086 158a 154c


### PR DESCRIPTION
Enable legacy SR-IOV in Broadcom BCM57504 NetXtreme-E device. Backport of:
https://github.com/openshift/sriov-network-operator/pull/808 https://github.com/openshift/sriov-network-operator/pull/809