### PR TITLE
OCPBUGS-16906: Never reduce MTU on PF

### DIFF
--- a/cmd/webhook/start.go
+++ b/cmd/webhook/start.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/fsnotify/fsnotify"
@@ -55,7 +55,7 @@ func init() {
 func serve(w http.ResponseWriter, r *http.Request, admit admitHandler) {
 	var body []byte
 	if r.Body != nil {
-		if data, err := ioutil.ReadAll(r.Body); err == nil {
+		if data, err := io.ReadAll(r.Body); err == nil {
 			body = data
 		}
 	}

--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -711,6 +711,9 @@ func createDevicePluginResource(
 	// Enable the selection of devices using NetFilter
 	if p.Spec.NicSelector.NetFilter != "" {
 		// Loop through interfaces status to find a match for NetworkID or NetworkTag
+		if len(nodeState.Status.Interfaces) == 0 {
+			return nil, fmt.Errorf("node state %s doesn't contain interfaces data", nodeState.Name)
+		}
 		for _, intf := range nodeState.Status.Interfaces {
 			if sriovnetworkv1.NetFilterMatch(p.Spec.NicSelector.NetFilter, intf.NetFilter) {
 				// Found a match add the Interfaces PciAddress

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -1056,7 +1055,7 @@ func tryCreateSwitchdevUdevRule(nodeState *sriovnetworkv1.SriovNetworkNodeState)
 		}
 	}
 
-	oldContent, err := ioutil.ReadFile(filePath)
+	oldContent, err := os.ReadFile(filePath)
 	// if oldContent = newContent, don't do anything
 	if err == nil && newContent == string(oldContent) {
 		return nil
@@ -1069,7 +1068,7 @@ func tryCreateSwitchdevUdevRule(nodeState *sriovnetworkv1.SriovNetworkNodeState)
 
 	// if the file does not exist or if oldContent != newContent
 	// write to file and create it if it doesn't exist
-	err = ioutil.WriteFile(filePath, []byte(newContent), 0664)
+	err = os.WriteFile(filePath, []byte(newContent), 0664)
 	if err != nil {
 		glog.Errorf("tryCreateSwitchdevUdevRule(): fail to write file: %v", err)
 		return err
@@ -1116,7 +1115,7 @@ func tryCreateNMUdevRule() error {
 	// add NM udev rules for renaming VF rep
 	newContent = newContent + "SUBSYSTEM==\"net\", ACTION==\"add|move\", ATTRS{phys_switch_id}!=\"\", ATTR{phys_port_name}==\"pf*vf*\", ENV{NM_UNMANAGED}=\"1\"\n"
 
-	oldContent, err := ioutil.ReadFile(filePath)
+	oldContent, err := os.ReadFile(filePath)
 	// if oldContent = newContent, don't do anything
 	if err == nil && newContent == string(oldContent) {
 		return nil
@@ -1135,7 +1134,7 @@ func tryCreateNMUdevRule() error {
 
 	// if the file does not exist or if oldContent != newContent
 	// write to file and create it if it doesn't exist
-	err = ioutil.WriteFile(filePath, []byte(newContent), 0666)
+	err = os.WriteFile(filePath, []byte(newContent), 0666)
 	if err != nil {
 		glog.Errorf("tryCreateNMUdevRule(): fail to write file: %v", err)
 		return err

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -3,7 +3,7 @@ package daemon
 import (
 	"context"
 	"flag"
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -321,7 +321,7 @@ func updateSriovNetworkNodeState(c snclientset.Interface, nodeState *sriovnetwor
 
 func assertFileContents(path, contents string) {
 	Eventually(func() (string, error) {
-		ret, err := ioutil.ReadFile(path)
+		ret, err := os.ReadFile(path)
 		return string(ret), err
 	}, "10s").WithOffset(1).Should(Equal(contents))
 }

--- a/pkg/plugins/k8s/k8s_plugin.go
+++ b/pkg/plugins/k8s/k8s_plugin.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -346,7 +345,7 @@ func (p *K8sPlugin) getSwitchDevSystemServices() []*service.Service {
 }
 
 func (p *K8sPlugin) isSwitchdevScriptNeedUpdate(scriptObj *service.ScriptManifestFile) (needUpdate bool, err error) {
-	data, err := ioutil.ReadFile(path.Join(chroot, scriptObj.Path))
+	data, err := os.ReadFile(path.Join(chroot, scriptObj.Path))
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return false, err
@@ -457,7 +456,7 @@ func (p *K8sPlugin) updateSwitchdevService() error {
 	}
 
 	if p.updateTarget.switchdevBeforeNMRunScript {
-		err := ioutil.WriteFile(path.Join(chroot, p.switchdevBeforeNMRunScript.Path),
+		err := os.WriteFile(path.Join(chroot, p.switchdevBeforeNMRunScript.Path),
 			[]byte(p.switchdevBeforeNMRunScript.Contents.Inline), 0755)
 		if err != nil {
 			return err
@@ -465,7 +464,7 @@ func (p *K8sPlugin) updateSwitchdevService() error {
 	}
 
 	if p.updateTarget.switchdevAfterNMRunScript {
-		err := ioutil.WriteFile(path.Join(chroot, p.switchdevAfterNMRunScript.Path),
+		err := os.WriteFile(path.Join(chroot, p.switchdevAfterNMRunScript.Path),
 			[]byte(p.switchdevAfterNMRunScript.Contents.Inline), 0755)
 		if err != nil {
 			return err
@@ -473,7 +472,7 @@ func (p *K8sPlugin) updateSwitchdevService() error {
 	}
 
 	if p.updateTarget.switchdevUdevScript {
-		err := ioutil.WriteFile(path.Join(chroot, p.switchdevUdevScript.Path),
+		err := os.WriteFile(path.Join(chroot, p.switchdevUdevScript.Path),
 			[]byte(p.switchdevUdevScript.Contents.Inline), 0755)
 		if err != nil {
 			return err

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -120,7 +119,7 @@ func renderTemplate(path string, d *RenderData) (*bytes.Buffer, error) {
 	tmpl.Funcs(template.FuncMap{"getOr": getOr, "isSet": isSet})
 	tmpl.Funcs(sprig.TxtFuncMap())
 
-	source, err := ioutil.ReadFile(path)
+	source, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read manifest %s", path)
 	}

--- a/pkg/service/service_manager.go
+++ b/pkg/service/service_manager.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -43,7 +42,7 @@ func (sm *serviceManager) IsServiceExist(servicePath string) (bool, error) {
 
 // ReadService read service from given path
 func (sm *serviceManager) ReadService(servicePath string) (*Service, error) {
-	data, err := ioutil.ReadFile(path.Join(sm.chroot, servicePath))
+	data, err := os.ReadFile(path.Join(sm.chroot, servicePath))
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +57,7 @@ func (sm *serviceManager) ReadService(servicePath string) (*Service, error) {
 // EnableService creates service file and enables it with systemctl enable
 func (sm *serviceManager) EnableService(service *Service) error {
 	// Write service file
-	err := ioutil.WriteFile(path.Join(sm.chroot, service.Path), []byte(service.Content), 0644)
+	err := os.WriteFile(path.Join(sm.chroot, service.Path), []byte(service.Content), 0644)
 	if err != nil {
 		return err
 	}

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -1,7 +1,8 @@
 package service
 
 import (
-	"io/ioutil"
+	"io"
+	"os"
 	"strings"
 
 	"github.com/coreos/go-systemd/v22/unit"
@@ -55,7 +56,7 @@ OUTER:
 		newServiceOptions = append(newServiceOptions, opt)
 	}
 
-	data, err := ioutil.ReadAll(unit.Serialize(newServiceOptions))
+	data, err := io.ReadAll(unit.Serialize(newServiceOptions))
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +85,7 @@ OUTER:
 		serviceOptions = append(serviceOptions, appendOpt)
 	}
 
-	data, err := ioutil.ReadAll(unit.Serialize(serviceOptions))
+	data, err := io.ReadAll(unit.Serialize(serviceOptions))
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +99,7 @@ OUTER:
 
 // ReadServiceInjectionManifestFile reads service injection file
 func ReadServiceInjectionManifestFile(path string) (*Service, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +118,7 @@ func ReadServiceInjectionManifestFile(path string) (*Service, error) {
 
 // ReadServiceManifestFile reads service file
 func ReadServiceManifestFile(path string) (*Service, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +137,7 @@ func ReadServiceManifestFile(path string) (*Service, error) {
 
 // ReadScriptManifestFile reads script file
 func ReadScriptManifestFile(path string) (*ScriptManifestFile, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/systemd/systemd.go
+++ b/pkg/systemd/systemd.go
@@ -18,7 +18,6 @@ package systemd
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -56,7 +55,7 @@ type SriovResult struct {
 }
 
 func ReadConfFile() (spec *SriovConfig, err error) {
-	rawConfig, err := ioutil.ReadFile(SriovSystemdConfigPath)
+	rawConfig, err := os.ReadFile(SriovSystemdConfigPath)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +100,7 @@ func WriteConfFile(newState *sriovnetworkv1.SriovNetworkNodeState, unsupportedNi
 		}
 	}
 
-	oldContent, err := ioutil.ReadFile(SriovHostSystemdConfigPath)
+	oldContent, err := os.ReadFile(SriovHostSystemdConfigPath)
 	if err != nil {
 		glog.Errorf("WriteConfFile(): fail to read file: %v", err)
 		return false, err
@@ -128,7 +127,7 @@ func WriteConfFile(newState *sriovnetworkv1.SriovNetworkNodeState, unsupportedNi
 	glog.V(2).Infof("WriteConfFile(): previews configuration is not equal: old config:\n%s\nnew config:\n%s\n", string(oldContent), string(newContent))
 
 	glog.V(2).Infof("WriteConfFile(): write '%s' to %s", newContent, SriovHostSystemdConfigPath)
-	err = ioutil.WriteFile(SriovHostSystemdConfigPath, newContent, 0644)
+	err = os.WriteFile(SriovHostSystemdConfigPath, newContent, 0644)
 	if err != nil {
 		glog.Errorf("WriteConfFile(): fail to write file: %v", err)
 		return false, err
@@ -167,7 +166,7 @@ func WriteSriovResult(result *SriovResult) error {
 	}
 
 	glog.V(2).Infof("WriteSriovResult(): write '%s' to %s", string(out), SriovSystemdResultPath)
-	err = ioutil.WriteFile(SriovSystemdResultPath, out, 0644)
+	err = os.WriteFile(SriovSystemdResultPath, out, 0644)
 	if err != nil {
 		glog.Errorf("WriteSriovResult(): failed to write sriov result file on path %s: %v", SriovSystemdResultPath, err)
 		return err
@@ -188,7 +187,7 @@ func ReadSriovResult() (*SriovResult, error) {
 		}
 	}
 
-	rawConfig, err := ioutil.ReadFile(SriovHostSystemdResultPath)
+	rawConfig, err := os.ReadFile(SriovHostSystemdResultPath)
 	if err != nil {
 		glog.Errorf("ReadSriovResult(): failed to read sriov result file on path %s: %v", SriovHostSystemdResultPath, err)
 		return nil, err
@@ -224,7 +223,7 @@ func WriteSriovSupportedNics() error {
 		rawNicList = append(rawNicList, []byte(fmt.Sprintf("%s\n", line))...)
 	}
 
-	err = ioutil.WriteFile(sriovHostSystemdSupportedNicPath, rawNicList, 0644)
+	err = os.WriteFile(sriovHostSystemdSupportedNicPath, rawNicList, 0644)
 	if err != nil {
 		glog.Errorf("WriteSriovSupportedNics(): failed to write sriov supporter nics ids file on path %s: %v", sriovHostSystemdSupportedNicPath, err)
 		return err
@@ -245,7 +244,7 @@ func ReadSriovSupportedNics() ([]string, error) {
 		}
 	}
 
-	rawConfig, err := ioutil.ReadFile(sriovSystemdSupportedNicPath)
+	rawConfig, err := os.ReadFile(sriovSystemdSupportedNicPath)
 	if err != nil {
 		glog.Errorf("ReadSriovSupportedNics(): failed to read sriov supporter nics file on path %s: %v", sriovSystemdSupportedNicPath, err)
 		return nil, err

--- a/pkg/utils/driver.go
+++ b/pkg/utils/driver.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -24,7 +23,7 @@ func Unbind(pciAddr string) error {
 	}
 
 	filePath := filepath.Join(sysBusPciDrivers, driver, "unbind")
-	err := ioutil.WriteFile(filePath, []byte(pciAddr), os.ModeAppend)
+	err := os.WriteFile(filePath, []byte(pciAddr), os.ModeAppend)
 	if err != nil {
 		glog.Errorf("Unbind(): fail to unbind driver for device %s. %s", pciAddr, err)
 		return err
@@ -49,13 +48,13 @@ func BindDpdkDriver(pciAddr, driver string) error {
 	}
 
 	driverOverridePath := filepath.Join(sysBusPciDevices, pciAddr, "driver_override")
-	err := ioutil.WriteFile(driverOverridePath, []byte(driver), os.ModeAppend)
+	err := os.WriteFile(driverOverridePath, []byte(driver), os.ModeAppend)
 	if err != nil {
 		glog.Errorf("BindDpdkDriver(): fail to write driver_override for device %s %s", driver, err)
 		return err
 	}
 	bindPath := filepath.Join(sysBusPciDrivers, driver, "bind")
-	err = ioutil.WriteFile(bindPath, []byte(pciAddr), os.ModeAppend)
+	err = os.WriteFile(bindPath, []byte(pciAddr), os.ModeAppend)
 	if err != nil {
 		glog.Errorf("BindDpdkDriver(): fail to bind driver for device %s: %s", pciAddr, err)
 		_, err := os.Readlink(filepath.Join(sysBusPciDevices, pciAddr, "iommu_group"))
@@ -65,7 +64,7 @@ func BindDpdkDriver(pciAddr, driver string) error {
 		}
 		return err
 	}
-	err = ioutil.WriteFile(driverOverridePath, []byte(""), os.ModeAppend)
+	err = os.WriteFile(driverOverridePath, []byte(""), os.ModeAppend)
 	if err != nil {
 		glog.Errorf("BindDpdkDriver(): fail to clear driver_override for device %s: %s", pciAddr, err)
 		return err
@@ -90,12 +89,12 @@ func BindDefaultDriver(pciAddr string) error {
 	}
 
 	driverOverridePath := filepath.Join(sysBusPciDevices, pciAddr, "driver_override")
-	err := ioutil.WriteFile(driverOverridePath, []byte("\x00"), os.ModeAppend)
+	err := os.WriteFile(driverOverridePath, []byte("\x00"), os.ModeAppend)
 	if err != nil {
 		glog.Errorf("BindDefaultDriver(): fail to write driver_override for device %s: %s", pciAddr, err)
 		return err
 	}
-	err = ioutil.WriteFile(sysBusPciDriversProbe, []byte(pciAddr), os.ModeAppend)
+	err = os.WriteFile(sysBusPciDriversProbe, []byte(pciAddr), os.ModeAppend)
 	if err != nil {
 		glog.Errorf("BindDefaultDriver(): fail to bind driver for device %s: %s", pciAddr, err)
 		return err

--- a/pkg/utils/sriov.go
+++ b/pkg/utils/sriov.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/golang/glog"
@@ -125,7 +124,7 @@ func WriteSwitchdevConfFile(newState *sriovnetworkv1.SriovNetworkNodeState) (upd
 			return
 		}
 	}
-	oldContent, err := ioutil.ReadFile(SriovHostSwitchDevConfPath)
+	oldContent, err := os.ReadFile(SriovHostSwitchDevConfPath)
 	if err != nil {
 		glog.Errorf("WriteSwitchdevConfFile(): fail to read file: %v", err)
 		return
@@ -145,7 +144,7 @@ func WriteSwitchdevConfFile(newState *sriovnetworkv1.SriovNetworkNodeState) (upd
 	}
 	update = true
 	glog.V(2).Infof("WriteSwitchdevConfFile(): write '%s' to switchdev.conf", newContent)
-	err = ioutil.WriteFile(SriovHostSwitchDevConfPath, newContent, 0644)
+	err = os.WriteFile(SriovHostSwitchDevConfPath, newContent, 0644)
 	if err != nil {
 		glog.Errorf("WriteSwitchdevConfFile(): fail to write file: %v", err)
 		return

--- a/pkg/utils/utils_virtual.go
+++ b/pkg/utils/utils_virtual.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -382,7 +381,7 @@ func tryToGetVirtualInterfaceName(pciAddr string) string {
 		return ""
 	}
 
-	fInfos, err := ioutil.ReadDir(netDir[0])
+	fInfos, err := os.ReadDir(netDir[0])
 	if err != nil {
 		glog.Warningf("tryToGetVirtualInterfaceName(): failed to read net directory %s: %q", netDir, err)
 		return ""

--- a/test/util/fakefilesystem/fakefilesystem.go
+++ b/test/util/fakefilesystem/fakefilesystem.go
@@ -2,7 +2,6 @@ package fakefilesystem
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 )
@@ -24,7 +23,7 @@ type FS struct {
 // ````
 func (f *FS) Use() (string, func(), error) {
 	// create the new fake fs root dir in /tmp/sriov...
-	rootDir, err := ioutil.TempDir("", "sriov-operator")
+	rootDir, err := os.MkdirTemp("", "sriov-operator")
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating fake root dir: %w", err)
 	}

--- a/test/util/netns/netns.go
+++ b/test/util/netns/netns.go
@@ -2,7 +2,6 @@ package netns
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -97,7 +96,7 @@ func setVfNetNs(pfPciAddr string, targetNetNs netns.NsHandle) error {
 			err.Error())
 	}
 
-	data, err := ioutil.ReadFile(numVfsFile)
+	data, err := os.ReadFile(numVfsFile)
 	if err != nil {
 		return fmt.Errorf("setVfNetNs(): failed to read '%s' from device with PCI address  '%s': '%s", numVfsFile, pfPciAddr,
 			err.Error())
@@ -119,7 +118,7 @@ func setVfNetNs(pfPciAddr string, targetNetNs netns.NsHandle) error {
 			continue
 		}
 
-		fInfos, err := ioutil.ReadDir(vfNetDir)
+		fInfos, err := os.ReadDir(vfNetDir)
 		if err != nil {
 			return fmt.Errorf("setVfNetNs(): failed to read '%s': '%s'", vfNetDir, err.Error())
 		}
@@ -149,7 +148,7 @@ func setLinkNetNs(pciAddr string, targetNetNs netns.NsHandle) error {
 	if _, err := os.Lstat(netDir); err != nil {
 		return fmt.Errorf("setLinkNetNs(): unable to find directory '%s': '%s'", netDir, err.Error())
 	}
-	fInfos, err := ioutil.ReadDir(netDir)
+	fInfos, err := os.ReadDir(netDir)
 	if err != nil {
 		return fmt.Errorf("setLinkNetNs(): failed to read '%s': '%s'", netDir, err.Error())
 	}


### PR DESCRIPTION
In case a policy specifying a different MTU, in the past, the MTU of the PF associated with the VFs would also be updated. Since reducing the MTU on PF could cause issues when the PF is used by other things too (i.e. primary network), reducing the MTU could cause connectivity issues. Therefore, take the conservative approach of never reducing the MTU on the PF when configuring the MTU on the VF.