### PR TITLE
OCPBUGS-18501: SR-IOV should reject bad MTU config in policy

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -299,7 +299,7 @@ func configSriovDevice(iface *sriovnetworkv1.Interface, ifaceStatus *sriovnetwor
 		}
 	}
 	// set PF mtu
-	if iface.Mtu > 0 && iface.Mtu != ifaceStatus.Mtu {
+	if iface.Mtu > 0 && iface.Mtu > ifaceStatus.Mtu {
 		err = setNetdevMTU(iface.PciAddress, iface.Mtu)
 		if err != nil {
 			glog.Warningf("configSriovDevice(): fail to set mtu for PF %s: %v", iface.PciAddress, err)


### PR DESCRIPTION
In case a policy specifying a different MTU, in the past, the MTU of the PF associated with the VFs would also be updated. Since reducing the MTU on PF could cause issues when the PF is used by other things too (i.e. primary network), reducing the MTU could cause connectivity issues. Therefore, take the conservative approach of never reducing the MTU on the PF when configuring the MTU on the VF.