### PR TITLE
OCPBUGS-19908: virtual: get real PCI address for each device found

### DIFF
--- a/bundle/manifests/supported-nic-ids_v1_configmap.yaml
+++ b/bundle/manifests/supported-nic-ids_v1_configmap.yaml
@@ -30,6 +30,7 @@ data:
   Qlogic_qede_QL45000_25G: 1077 1656 1664
   Qlogic_qede_QL45000_50G: 1077 1654 1664
   Red_Hat_Virtio_network_device: 1af4 1000 1000
+  Red_Hat_Virtio_1_0_network_device: 1af4 1041 1041
 kind: ConfigMap
 metadata:
   name: supported-nic-ids

--- a/config/manifests/bases/sriov-network-operator_configmap.yaml
+++ b/config/manifests/bases/sriov-network-operator_configmap.yaml
@@ -33,3 +33,4 @@ data:
   Qlogic_qede_QL45000_25G: "1077 1656 1664"
   Qlogic_qede_QL45000_50G: "1077 1654 1664"
   Red_Hat_Virtio_network_device: "1af4 1000 1000"
+  Red_Hat_Virtio_1_0_network_device: "1af4 1041 1041"

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -30,6 +30,7 @@ data:
   Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"
   Qlogic_qede_QL45000_50G: "1077 1654 1664"
   Red_Hat_Virtio_network_device: "1af4 1000 1000"
+  Red_Hat_Virtio_1_0_network_device: "1af4 1041 1041"
   Marvell_OCTEON_TX2_CN96XX: "177d b200 b203"
   Marvell_OCTEON_TX2_CN98XX: "177d b100 b103"
   Marvell_OCTEON_Fusion_CNF95XX: "177d b600 b603"

--- a/deployment/sriov-network-operator/templates/configmap.yaml
+++ b/deployment/sriov-network-operator/templates/configmap.yaml
@@ -30,6 +30,7 @@ data:
   Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"
   Qlogic_qede_QL45000_50G: "1077 1654 1664"
   Red_Hat_Virtio_network_device: "1af4 1000 1000"
+  Red_Hat_Virtio_1_0_network_device: "1af4 1041 1041"
   Marvell_OCTEON_TX2_CN96XX: "177d b200 b203"
   Marvell_OCTEON_TX2_CN98XX: "177d b100 b103"
   Marvell_OCTEON_Fusion_CNF95XX: "177d b600 b603"

--- a/manifests/stable/supported-nic-ids_v1_configmap.yaml
+++ b/manifests/stable/supported-nic-ids_v1_configmap.yaml
@@ -32,7 +32,8 @@ data:
   Qlogic_qede_QL41000: 1077 8070 8090
   Qlogic_qede_QL45000_25G: 1077 1656 1664
   Qlogic_qede_QL45000_50G: 1077 1654 1664
-  Red_Hat_Virtio_network_device: "1af4 1000 1000"
+  Red_Hat_Virtio_network_device: 1af4 1000 1000
+  Red_Hat_Virtio_1_0_network_device: 1af4 1041 1041
 kind: ConfigMap
 metadata:
   name: supported-nic-ids

--- a/pkg/utils/utils_virtual.go
+++ b/pkg/utils/utils_virtual.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/hashicorp/go-retryablehttp"
@@ -118,6 +119,27 @@ func GetOpenstackData(useHostPath bool) (metaData *OSPMetaData, networkData *OSP
 	if err != nil {
 		metaData, networkData, err = getOpenstackDataFromMetadataService()
 	}
+
+	// We can't rely on the PCI address from the metadata so we will lookup the real PCI address
+	// for the NIC that matches the MAC address.
+	//
+	// Libvirt/QEMU cannot guarantee that the address specified in the XML will match the address seen by the guest.
+	// This is a well known limitation: https://libvirt.org/pci-addresses.html
+	// When using the q35 machine type, it highlights this issue due to the change from using PCI to PCI-E bus for virtual devices.
+	//
+	// With that said, the PCI value in Nova Metadata is a best effort hint due to the limitations mentioned above. Therefore
+	// we will lookup the real PCI address for the NIC that matches the MAC address.
+	for i, device := range metaData.Devices {
+		realPCIAddr, err := getPCIAddressFromMACAddress(device.Mac)
+		if err != nil {
+			return metaData, networkData, fmt.Errorf("GetOpenstackData(): error getting PCI address for device %s: %w", device.Mac, err)
+		}
+		if realPCIAddr != device.Address {
+			glog.V(2).Infof("GetOpenstackData(): PCI address for device %s does not match Nova metadata value %s, it'll be overwritten with %s", device.Mac, device.Address, realPCIAddr)
+		}
+		metaData.Devices[i].Address = realPCIAddr
+	}
+
 	return metaData, networkData, err
 }
 
@@ -203,6 +225,33 @@ func getOpenstackDataFromMetadataService() (metaData *OSPMetaData, networkData *
 		return metaData, networkData, fmt.Errorf("error unmarshalling raw bytes %v from %s", err, ospNetworkDataURL)
 	}
 	return metaData, networkData, nil
+}
+
+// getPCIAddressFromMACAddress returns the PCI address of a device given its MAC address
+func getPCIAddressFromMACAddress(macAddress string) (string, error) {
+	nics, err := ghw.Network()
+	if err != nil {
+		return "", fmt.Errorf("error getting network info: %w", err)
+	}
+
+	var pciAddress string
+	for _, nic := range nics.NICs {
+		if strings.EqualFold(nic.MacAddress, macAddress) {
+			if pciAddress == "" {
+				pciAddress = *nic.PCIAddress
+			} else {
+				// Check if there are more than one device with the same MAC address
+				// and return an error if that's the case, we don't support that scenario for now.
+				return "", fmt.Errorf("more than one device found with MAC address %s", macAddress)
+			}
+		}
+	}
+
+	if pciAddress != "" {
+		return pciAddress, nil
+	}
+
+	return "", fmt.Errorf("no device found with MAC address %s", macAddress)
 }
 
 // CreateOpenstackDevicesInfo create the openstack device info map


### PR DESCRIPTION
We can't rely on the PCI address from the metadata so we will lookup the real PCI address
for the NIC that matches the MAC address.

Libvirt/QEMU cannot guarantee that the address specified in the XML will match the address seen by the guest.
This is a well known limitation: https://libvirt.org/pci-addresses.html
When using the q35 machine type, it highlights this issue due to the change from using PCI to PCI-E bus for virtual devices.

With that said, the PCI value in Nova Metadata is a best effort hint due to the limitations mentioned above. Therefore
we will lookup the real PCI address for the NIC that matches the MAC address.

This PR also adds  Virtio 1.0 network device as supported

https://devicehunt.com/view/type/pci/vendor/1AF4/device/1041
https://qemu.readthedocs.io/en/master/specs/pci-ids.html

Modern QEMU brings up virtio 1.0 network device, we need to support that
for DPDK.