### PR TITLE
OCPBUGS-20211: update version to 4.15

### DIFF
--- a/Makefile.bundle
+++ b/Makefile.bundle
@@ -1,6 +1,6 @@
 include Makefile
 # Current Operator version
-VERSION ?= 4.14.0
+VERSION ?= 4.15.0
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
 

--- a/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
@@ -103,7 +103,7 @@ metadata:
     createdAt: "2023-10-23T08:39:21Z"
     description: An operator for configuring SR-IOV components and initializing SRIOV
       network devices in Openshift cluster.
-    olm.skipRange: '>=4.3.0-0 <4.14.0'
+    olm.skipRange: '>=4.3.0-0 <4.15.0'
     operatorframework.io/suggested-namespace: openshift-sriov-network-operator
     operators.openshift.io/infrastructure-features: '["disconnected", "cni"]'
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
@@ -114,7 +114,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
-  name: sriov-network-operator.v4.14.0
+  name: sriov-network-operator.v4.15.0
   namespace: openshift-sriov-network-operator
 spec:
   apiservicedefinitions: {}
@@ -330,19 +330,19 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: SRIOV_CNI_IMAGE
-                  value: quay.io/openshift/origin-sriov-cni:4.14
+                  value: quay.io/openshift/origin-sriov-cni:4.15
                 - name: SRIOV_DEVICE_PLUGIN_IMAGE
-                  value: quay.io/openshift/origin-sriov-network-device-plugin:4.14
+                  value: quay.io/openshift/origin-sriov-network-device-plugin:4.15
                 - name: NETWORK_RESOURCES_INJECTOR_IMAGE
-                  value: quay.io/openshift/origin-sriov-dp-admission-controller:4.14
+                  value: quay.io/openshift/origin-sriov-dp-admission-controller:4.15
                 - name: OPERATOR_NAME
                   value: sriov-network-operator
                 - name: SRIOV_NETWORK_CONFIG_DAEMON_IMAGE
-                  value: quay.io/openshift/origin-sriov-network-config-daemon:4.14
+                  value: quay.io/openshift/origin-sriov-network-config-daemon:4.15
                 - name: SRIOV_NETWORK_WEBHOOK_IMAGE
-                  value: quay.io/openshift/origin-sriov-network-webhook:4.14
+                  value: quay.io/openshift/origin-sriov-network-webhook:4.15
                 - name: SRIOV_INFINIBAND_CNI_IMAGE
-                  value: quay.io/openshift/origin-sriov-infiniband-cni:4.14
+                  value: quay.io/openshift/origin-sriov-infiniband-cni:4.15
                 - name: RESOURCE_PREFIX
                   value: openshift.io
                 - name: ENABLE_ADMISSION_CONTROLLER
@@ -360,8 +360,8 @@ spec:
                     fieldRef:
                       fieldPath: metadata.name
                 - name: RELEASE_VERSION
-                  value: 4.14.0
-                image: quay.io/openshift/origin-sriov-network-operator:4.14
+                  value: 4.15.0
+                image: quay.io/openshift/origin-sriov-network-operator:4.15
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:
@@ -526,7 +526,7 @@ spec:
   - sriov
   labels:
     olm-owner-enterprise-app: sriov-network-operator
-    olm-status-descriptors: sriov-network-operator.v4.14.0
+    olm-status-descriptors: sriov-network-operator.v4.15.0
   links:
   - name: Source Code
     url: https://github.com/k8snetworkplumbingwg/sriov-network-operator
@@ -535,4 +535,4 @@ spec:
     name: Red Hat
   provider:
     name: Red Hat
-  version: 4.14.0
+  version: 4.15.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,7 +33,7 @@ spec:
         operator: Exists
       containers:
       - name: sriov-network-operator
-        image: quay.io/openshift/origin-sriov-network-operator:4.14
+        image: quay.io/openshift/origin-sriov-network-operator:4.15
         command:
         - sriov-network-operator
         args:
@@ -57,19 +57,19 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: SRIOV_CNI_IMAGE
-            value: quay.io/openshift/origin-sriov-cni:4.14
+            value: quay.io/openshift/origin-sriov-cni:4.15
           - name: SRIOV_DEVICE_PLUGIN_IMAGE
-            value: quay.io/openshift/origin-sriov-network-device-plugin:4.14
+            value: quay.io/openshift/origin-sriov-network-device-plugin:4.15
           - name: NETWORK_RESOURCES_INJECTOR_IMAGE
-            value: quay.io/openshift/origin-sriov-dp-admission-controller:4.14
+            value: quay.io/openshift/origin-sriov-dp-admission-controller:4.15
           - name: OPERATOR_NAME
             value: sriov-network-operator
           - name: SRIOV_NETWORK_CONFIG_DAEMON_IMAGE
-            value: quay.io/openshift/origin-sriov-network-config-daemon:4.14
+            value: quay.io/openshift/origin-sriov-network-config-daemon:4.15
           - name: SRIOV_NETWORK_WEBHOOK_IMAGE
-            value: quay.io/openshift/origin-sriov-network-webhook:4.14
+            value: quay.io/openshift/origin-sriov-network-webhook:4.15
           - name: SRIOV_INFINIBAND_CNI_IMAGE
-            value: quay.io/openshift/origin-sriov-infiniband-cni:4.14
+            value: quay.io/openshift/origin-sriov-infiniband-cni:4.15
           - name: RESOURCE_PREFIX
             value: openshift.io
           - name: ENABLE_ADMISSION_CONTROLLER
@@ -87,4 +87,4 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
           - name: RELEASE_VERSION
-            value: 4.14.0
+            value: 4.15.0

--- a/config/manifests/bases/sriov-network-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sriov-network-operator.clusterserviceversion.yaml
@@ -10,7 +10,7 @@ metadata:
     createdAt: 2019/04/30
     description: An operator for configuring SR-IOV components and initializing SRIOV
       network devices in Openshift cluster.
-    olm.skipRange: '>=4.3.0-0 <4.14.0'
+    olm.skipRange: '>=4.3.0-0 <4.15.0'
     operatorframework.io/suggested-namespace: openshift-sriov-network-operator
     operators.openshift.io/infrastructure-features: '["disconnected", "cni"]'
     repository: https://github.com/k8snetworkplumbingwg/sriov-network-operator
@@ -112,19 +112,19 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 - name: SRIOV_CNI_IMAGE
-                  value: quay.io/openshift/origin-sriov-cni:4.14
+                  value: quay.io/openshift/origin-sriov-cni:4.15
                 - name: SRIOV_DEVICE_PLUGIN_IMAGE
-                  value: quay.io/openshift/origin-sriov-network-device-plugin:4.14
+                  value: quay.io/openshift/origin-sriov-network-device-plugin:4.15
                 - name: NETWORK_RESOURCES_INJECTOR_IMAGE
-                  value: quay.io/openshift/origin-sriov-dp-admission-controller:4.14
+                  value: quay.io/openshift/origin-sriov-dp-admission-controller:4.15
                 - name: OPERATOR_NAME
                   value: sriov-network-operator
                 - name: SRIOV_NETWORK_CONFIG_DAEMON_IMAGE
-                  value: quay.io/openshift/origin-sriov-network-config-daemon:4.14
+                  value: quay.io/openshift/origin-sriov-network-config-daemon:4.15
                 - name: SRIOV_NETWORK_WEBHOOK_IMAGE
-                  value: quay.io/openshift/origin-sriov-network-webhook:4.14
+                  value: quay.io/openshift/origin-sriov-network-webhook:4.15
                 - name: SRIOV_INFINIBAND_CNI_IMAGE
-                  value: quay.io/openshift/origin-sriov-infiniband-cni:4.14
+                  value: quay.io/openshift/origin-sriov-infiniband-cni:4.15
                 - name: RESOURCE_PREFIX
                   value: openshift.io
                 - name: ENABLE_ADMISSION_CONTROLLER
@@ -138,7 +138,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.name
                 - name: RELEASE_VERSION
-                  value: 4.14.0
+                  value: 4.15.0
                 image: quay.io/pliurh/sriov-network-operator-manager:bd1
                 imagePullPolicy: IfNotPresent
                 name: sriov-network-operator
@@ -166,7 +166,7 @@ spec:
   - sriov
   labels:
     olm-owner-enterprise-app: sriov-network-operator
-    olm-status-descriptors: sriov-network-operator.v4.14.0
+    olm-status-descriptors: sriov-network-operator.v4.15.0
   links:
   - name: Source Code
     url: https://github.com/k8snetworkplumbingwg/sriov-network-operator
@@ -175,4 +175,4 @@ spec:
     name: Red Hat
   provider:
     name: Red Hat
-  version: 4.14.0
+  version: 4.15.0

--- a/manifests/sriov-network-operator.package.yaml
+++ b/manifests/sriov-network-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: sriov-network-operator
 channels:
 - name: "stable"
-  currentCSV: sriov-network-operator.v4.14.0
+  currentCSV: sriov-network-operator.v4.15.0

--- a/manifests/stable/image-references
+++ b/manifests/stable/image-references
@@ -6,28 +6,28 @@ spec:
   - name: sriov-network-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sriov-network-operator:4.14
+      name: quay.io/openshift/origin-sriov-network-operator:4.15
   - name: sriov-network-config-daemon
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sriov-network-config-daemon:4.14
+      name: quay.io/openshift/origin-sriov-network-config-daemon:4.15
   - name: sriov-cni
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sriov-cni:4.14
+      name: quay.io/openshift/origin-sriov-cni:4.15
   - name: sriov-network-device-plugin
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sriov-network-device-plugin:4.14
+      name: quay.io/openshift/origin-sriov-network-device-plugin:4.15
   - name: sriov-dp-admission-controller
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sriov-dp-admission-controller:4.14
+      name: quay.io/openshift/origin-sriov-dp-admission-controller:4.15
   - name: sriov-network-webhook
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sriov-network-webhook:4.14
+      name: quay.io/openshift/origin-sriov-network-webhook:4.15
   - name: sriov-infiniband-cni
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sriov-infiniband-cni:4.14
+      name: quay.io/openshift/origin-sriov-infiniband-cni:4.15

--- a/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
+++ b/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
@@ -103,7 +103,7 @@ metadata:
     createdAt: "2023-10-23T08:39:21Z"
     description: An operator for configuring SR-IOV components and initializing SRIOV
       network devices in Openshift cluster.
-    olm.skipRange: '>=4.3.0-0 <4.14.0'
+    olm.skipRange: '>=4.3.0-0 <4.15.0'
     operatorframework.io/suggested-namespace: openshift-sriov-network-operator
     operators.openshift.io/infrastructure-features: '["disconnected", "cni"]'
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
@@ -114,7 +114,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
-  name: sriov-network-operator.v4.14.0
+  name: sriov-network-operator.v4.15.0
   namespace: openshift-sriov-network-operator
 spec:
   apiservicedefinitions: {}
@@ -330,19 +330,19 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: SRIOV_CNI_IMAGE
-                  value: quay.io/openshift/origin-sriov-cni:4.14
+                  value: quay.io/openshift/origin-sriov-cni:4.15
                 - name: SRIOV_DEVICE_PLUGIN_IMAGE
-                  value: quay.io/openshift/origin-sriov-network-device-plugin:4.14
+                  value: quay.io/openshift/origin-sriov-network-device-plugin:4.15
                 - name: NETWORK_RESOURCES_INJECTOR_IMAGE
-                  value: quay.io/openshift/origin-sriov-dp-admission-controller:4.14
+                  value: quay.io/openshift/origin-sriov-dp-admission-controller:4.15
                 - name: OPERATOR_NAME
                   value: sriov-network-operator
                 - name: SRIOV_NETWORK_CONFIG_DAEMON_IMAGE
-                  value: quay.io/openshift/origin-sriov-network-config-daemon:4.14
+                  value: quay.io/openshift/origin-sriov-network-config-daemon:4.15
                 - name: SRIOV_NETWORK_WEBHOOK_IMAGE
-                  value: quay.io/openshift/origin-sriov-network-webhook:4.14
+                  value: quay.io/openshift/origin-sriov-network-webhook:4.15
                 - name: SRIOV_INFINIBAND_CNI_IMAGE
-                  value: quay.io/openshift/origin-sriov-infiniband-cni:4.14
+                  value: quay.io/openshift/origin-sriov-infiniband-cni:4.15
                 - name: RESOURCE_PREFIX
                   value: openshift.io
                 - name: ENABLE_ADMISSION_CONTROLLER
@@ -360,8 +360,8 @@ spec:
                     fieldRef:
                       fieldPath: metadata.name
                 - name: RELEASE_VERSION
-                  value: 4.14.0
-                image: quay.io/openshift/origin-sriov-network-operator:4.14
+                  value: 4.15.0
+                image: quay.io/openshift/origin-sriov-network-operator:4.15
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:
@@ -526,7 +526,7 @@ spec:
   - sriov
   labels:
     olm-owner-enterprise-app: sriov-network-operator
-    olm-status-descriptors: sriov-network-operator.v4.14.0
+    olm-status-descriptors: sriov-network-operator.v4.15.0
   links:
   - name: Source Code
     url: https://github.com/k8snetworkplumbingwg/sriov-network-operator
@@ -535,4 +535,4 @@ spec:
     name: Red Hat
   provider:
     name: Red Hat
-  version: 4.14.0
+  version: 4.15.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -10,10 +10,10 @@ import (
 var (
 	// Raw is the string representation of the version. This will be replaced
 	// with the calculated version at build time.
-	Raw = "v4.14.0"
+	Raw = "v4.15.0"
 
 	// Version is semver representation of the version.
-	Version = semver.MustParse("4.14.0")
+	Version = semver.MustParse("4.15.0")
 
 	// String is the human-friendly representation of the version.
 	String = fmt.Sprintf("SriovNetworkConfigOperator %s", Raw)


### PR DESCRIPTION
updated references from 4.14 to 4.15 via:

```
find . -not -path "./vendor*" -type f -print0 | xargs -0 sed -i 's/4\.14/4.15/g'
 make -f Makefile.bundle bundle
```

cc @wizhaoredhat, @bn222 