### PR TITLE
[downstream-only] Support RH Virtio 1.0 network device

### DIFF
--- a/bundle/manifests/supported-nic-ids_v1_configmap.yaml
+++ b/bundle/manifests/supported-nic-ids_v1_configmap.yaml
@@ -30,6 +30,7 @@ data:
   Qlogic_qede_QL45000_25G: 1077 1656 1664
   Qlogic_qede_QL45000_50G: 1077 1654 1664
   Red_Hat_Virtio_network_device: 1af4 1000 1000
+  Red_Hat_Virtio_1_0_network_device: 1af4 1041 1041
 kind: ConfigMap
 metadata:
   name: supported-nic-ids

--- a/config/manifests/bases/sriov-network-operator_configmap.yaml
+++ b/config/manifests/bases/sriov-network-operator_configmap.yaml
@@ -33,3 +33,4 @@ data:
   Qlogic_qede_QL45000_25G: "1077 1656 1664"
   Qlogic_qede_QL45000_50G: "1077 1654 1664"
   Red_Hat_Virtio_network_device: "1af4 1000 1000"
+  Red_Hat_Virtio_1_0_network_device: "1af4 1041 1041"

--- a/manifests/stable/supported-nic-ids_v1_configmap.yaml
+++ b/manifests/stable/supported-nic-ids_v1_configmap.yaml
@@ -32,7 +32,8 @@ data:
   Qlogic_qede_QL41000: 1077 8070 8090
   Qlogic_qede_QL45000_25G: 1077 1656 1664
   Qlogic_qede_QL45000_50G: 1077 1654 1664
-  Red_Hat_Virtio_network_device: "1af4 1000 1000"
+  Red_Hat_Virtio_network_device: 1af4 1000 1000
+  Red_Hat_Virtio_1_0_network_device: 1af4 1041 1041
 kind: ConfigMap
 metadata:
   name: supported-nic-ids


### PR DESCRIPTION
For DPDK on virtualized environments, we need this device to be
supported.
This was added upstream but missed during a downstream sync because
these files are only for OpenShift.

Note that we already support RH Virtio network device. This new device
is for the recent versions of QEMU.
