### PR TITLE
OCPBUGS-22904: Match origin image to configured image reference

### DIFF
--- a/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/pliurh/sriov-network-operator-manager:bd1
+    containerImage: quay.io/openshift/origin-sriov-network-operator:4.14
     createdAt: "2023-09-13T15:07:44Z"
     description: An operator for configuring SR-IOV components and initializing SRIOV
       network devices in Openshift cluster.

--- a/config/manifests/bases/sriov-network-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sriov-network-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/pliurh/sriov-network-operator-manager:bd1
+    containerImage: quay.io/openshift/origin-sriov-network-operator:4.14
     createdAt: 2019/04/30
     description: An operator for configuring SR-IOV components and initializing SRIOV
       network devices in Openshift cluster.
@@ -139,7 +139,7 @@ spec:
                       fieldPath: metadata.name
                 - name: RELEASE_VERSION
                   value: 4.14.0
-                image: quay.io/pliurh/sriov-network-operator-manager:bd1
+                image: quay.io/openshift/origin-sriov-network-operator:4.14
                 imagePullPolicy: IfNotPresent
                 name: sriov-network-operator
                 resources: {}

--- a/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
+++ b/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/pliurh/sriov-network-operator-manager:bd1
+    containerImage: quay.io/openshift/origin-sriov-network-operator:4.14
     createdAt: "2023-09-13T15:07:44Z"
     description: An operator for configuring SR-IOV components and initializing SRIOV
       network devices in Openshift cluster.


### PR DESCRIPTION
Since [image-references](https://github.com/openshift/sriov-network-operator/blob/release-4.14/manifests/stable/image-references) are configured by version for this repo.