### PR TITLE
OCPBUGS-24231: Fix config daemon annotation override

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -16,8 +16,6 @@ spec:
       maxUnavailable: 33%
   template:
     metadata:
-      annotations:
-        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: sriov-network-config-daemon
         component: network
@@ -25,6 +23,7 @@ spec:
         openshift.io/component: network
       annotations:
         kubectl.kubernetes.io/default-container: sriov-network-config-daemon
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       hostNetwork: true
       hostPID: true


### PR DESCRIPTION
A downstream merge [1][2] overrode the annotations in the config daemonset. This resulted in he sriov-network-config-daemon pod missing the `target.workload.openshift.io/management` annotation which led to the pod not being pinned to the management cores when workload partitioning is enabled.

This is a downstream-only patch.

[1] https://github.com/openshift/sriov-network-operator/pull/868
[2] commit 0f177536b2db307af95d251548bd5c055e2b543c