### PR TITLE
OCPBUGS-25924: envtest: Stick to a specific setup-envtest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ kustomize: ## Download kustomize locally if necessary.
 
 ENVTEST = $(BIN_DIR)/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.16)
 
 GOMOCK = $(shell pwd)/bin/mockgen
 gomock:


### PR DESCRIPTION
Using `@latest` for tools dependecies produces unrepeatable builds which might break at any point in time. This is particularly important when maintaining released versions which need a backport fix.

Note: At the moment is not possible to reference the package `sigs.k8s.io/controller-runtime/tools/setup-envtest` with a specific version:

```
go: sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.16.3: module sigs.k8s.io/controller-runtime@v0.16.3 found, but does not contain package sigs.k8s.io/controller-runtime/tools/setup-envtest
```

See https://github.com/kubernetes-sigs/kubebuilder/issues/2480

Ref:
https://github.com/openshift/sriov-network-operator/pull/849