### PR TITLE
OCPBUGS-26220: [release-4.15] Use default `{ib-}sriov-cni` entrypoint script

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -43,10 +43,7 @@ spec:
       initContainers:
         - name: sriov-cni
           image: {{.SRIOVCNIImage}}
-          command:
-            - /bin/sh
-            - -c
-            - cp /usr/bin/sriov /host/opt/cni/bin/
+          args: ["--no-sleep"]
           securityContext:
             privileged: true
           resources:
@@ -56,12 +53,12 @@ spec:
           volumeMounts:
             - name: cnibin
               mountPath: /host/opt/cni/bin
+            - name: os-release
+              mountPath: /host/etc/os-release
+              readOnly: true
         - name: sriov-infiniband-cni
           image: {{.SRIOVInfiniBandCNIImage}}
-          command:
-            - /bin/sh
-            - -c
-            - cp /usr/bin/ib-sriov /host/opt/cni/bin/
+          args: ["--no-sleep"]
           securityContext:
             privileged: true
           resources:
@@ -71,6 +68,9 @@ spec:
           volumeMounts:
             - name: cnibin
               mountPath: /host/opt/cni/bin
+            - name: os-release
+              mountPath: /host/etc/os-release
+              readOnly: true
       {{- if .UsedSystemdMode}}
         - name: sriov-service-copy
           image: {{.Image}}
@@ -131,3 +131,7 @@ spec:
       - name: cnibin
         hostPath:
           path: {{.CNIBinPath}}
+      - name: os-release
+        hostPath:
+          path: /etc/os-release
+          type: File


### PR DESCRIPTION
Backport of-
- https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/581

Depends on:
- https://github.com/openshift/ib-sriov-cni/pull/48
- https://github.com/openshift/sriov-cni/pull/100
