### PR TITLE
Fix bad merge in env.sh for OVS_CNI_IMAGE variable

### DIFF
--- a/hack/env.sh
+++ b/hack/env.sh
@@ -10,7 +10,7 @@ if [ -z $SKIP_VAR_SET ]; then
         export SRIOV_INFINIBAND_CNI_IMAGE=${SRIOV_INFINIBAND_CNI_IMAGE:-quay.io/openshift/origin-sriov-infiniband-cni@${INFINIBAND_CNI_IMAGE_DIGEST}}
         # OVS_CNI_IMAGE can be explicitly set to empty value, use default only if the var is not set
         OVS_CNI_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/kubevirt/ovs-cni-plugin | jq --raw-output '.Digest')
-        export OVS_CNI_IMAGE={OVS_CNI_IMAGE:-quay.io/kubevirt/ovs-cni-plugin@${OVS_CNI_IMAGE_DIGEST}}
+        export OVS_CNI_IMAGE=${OVS_CNI_IMAGE:-quay.io/kubevirt/ovs-cni-plugin@${OVS_CNI_IMAGE_DIGEST}}
         DP_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/openshift/origin-sriov-network-device-plugin | jq --raw-output '.Digest')
         export SRIOV_DEVICE_PLUGIN_IMAGE=${SRIOV_DEVICE_PLUGIN_IMAGE:-quay.io/openshift/origin-sriov-network-device-plugin@${DP_IMAGE_DIGEST}}
         INJECTOR_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/openshift/origin-sriov-dp-admission-controller | jq --raw-output '.Digest')


### PR DESCRIPTION
This also leads to a failure during deploy:
```
+ oc apply -n openshift-sriov-network-operator --validate=false -f -
Error from server (BadRequest): error when creating "STDIN": Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal object into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```
Fixes: c77576f336d7 ('Merge branch 'master' into sync-2024-04-09')