### PR TITLE
CNF-12007: d/s: CSV adjustment for `sriov-network-metrics-exporter`

### DIFF
--- a/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
@@ -100,7 +100,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-sriov-network-operator:4.17
-    createdAt: "2024-07-17T16:58:50Z"
+    createdAt: "2024-07-29T07:35:08Z"
     description: An operator for configuring SR-IOV components and initializing SRIOV
       network devices in Openshift cluster.
     features.operators.openshift.io/cnf: "false"
@@ -114,6 +114,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=4.3.0-0 <4.17.0'
+    operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/initialization-resource: |-
       {
         "apiVersion": "sriovnetwork.openshift.io/v1",
@@ -394,6 +395,20 @@ spec:
                   value: operator-webhook-service
                 - name: ADMISSION_CONTROLLERS_CERTIFICATES_INJECTOR_SECRET_NAME
                   value: network-resources-injector-secret
+                - name: METRICS_EXPORTER_IMAGE
+                  value: quay.io/openshift/origin-sriov-network-metrics-exporter:4.17
+                - name: METRICS_EXPORTER_KUBE_RBAC_PROXY_IMAGE
+                  value: quay.io/openshift/origin-kube-rbac-proxy:4.17
+                - name: METRICS_EXPORTER_SECRET_NAME
+                  value: metrics-exporter-cert
+                - name: METRICS_EXPORTER_PROMETHEUS_OPERATOR_ENABLED
+                  value: "true"
+                - name: METRICS_EXPORTER_PROMETHEUS_OPERATOR_NAMESPACE
+                  value: openshift-monitoring
+                - name: METRICS_EXPORTER_PROMETHEUS_OPERATOR_SERVICE_ACCOUNT
+                  value: prometheus-k8s
+                - name: METRICS_EXPORTER_PORT
+                  value: "9110"
                 - name: NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -541,6 +556,7 @@ spec:
           - monitoring.coreos.com
           resources:
           - servicemonitors
+          - prometheusrules
           verbs:
           - get
           - create

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -83,6 +83,20 @@ spec:
             value: operator-webhook-service
           - name: ADMISSION_CONTROLLERS_CERTIFICATES_INJECTOR_SECRET_NAME
             value: network-resources-injector-secret
+          - name: METRICS_EXPORTER_IMAGE
+            value: quay.io/openshift/origin-sriov-network-metrics-exporter:4.17
+          - name: METRICS_EXPORTER_KUBE_RBAC_PROXY_IMAGE
+            value: quay.io/openshift/origin-kube-rbac-proxy:4.17
+          - name: METRICS_EXPORTER_SECRET_NAME
+            value: metrics-exporter-cert
+          - name: METRICS_EXPORTER_PROMETHEUS_OPERATOR_ENABLED
+            value: "true"
+          - name: METRICS_EXPORTER_PROMETHEUS_OPERATOR_NAMESPACE
+            value: openshift-monitoring
+          - name: METRICS_EXPORTER_PROMETHEUS_OPERATOR_SERVICE_ACCOUNT
+            value: prometheus-k8s
+          - name: METRICS_EXPORTER_PORT
+            value: "9110"
           - name: NAMESPACE
             valueFrom:
               fieldRef:

--- a/config/manifests/bases/sriov-network-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sriov-network-operator.clusterserviceversion.yaml
@@ -21,6 +21,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=4.3.0-0 <4.17.0'
+    operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/initialization-resource: |-
       {
         "apiVersion": "sriovnetwork.openshift.io/v1",

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -29,6 +29,7 @@ rules:
   - monitoring.coreos.com
   resources:
   - servicemonitors
+  - prometheusrules
   verbs:
   - get
   - create

--- a/manifests/stable/image-references
+++ b/manifests/stable/image-references
@@ -35,3 +35,12 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-rdma-cni:4.17
+  - name: sriov-network-metrics-exporter
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-sriov-network-metrics-exporter:4.17
+  - name: kube-rbac-proxy
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-kube-rbac-proxy:4.17      
+

--- a/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
+++ b/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
@@ -100,7 +100,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-sriov-network-operator:4.17
-    createdAt: "2024-07-17T16:58:50Z"
+    createdAt: "2024-07-29T07:35:08Z"
     description: An operator for configuring SR-IOV components and initializing SRIOV
       network devices in Openshift cluster.
     features.operators.openshift.io/cnf: "false"
@@ -114,6 +114,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=4.3.0-0 <4.17.0'
+    operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/initialization-resource: |-
       {
         "apiVersion": "sriovnetwork.openshift.io/v1",
@@ -394,6 +395,20 @@ spec:
                   value: operator-webhook-service
                 - name: ADMISSION_CONTROLLERS_CERTIFICATES_INJECTOR_SECRET_NAME
                   value: network-resources-injector-secret
+                - name: METRICS_EXPORTER_IMAGE
+                  value: quay.io/openshift/origin-sriov-network-metrics-exporter:4.17
+                - name: METRICS_EXPORTER_KUBE_RBAC_PROXY_IMAGE
+                  value: quay.io/openshift/origin-kube-rbac-proxy:4.17
+                - name: METRICS_EXPORTER_SECRET_NAME
+                  value: metrics-exporter-cert
+                - name: METRICS_EXPORTER_PROMETHEUS_OPERATOR_ENABLED
+                  value: "true"
+                - name: METRICS_EXPORTER_PROMETHEUS_OPERATOR_NAMESPACE
+                  value: openshift-monitoring
+                - name: METRICS_EXPORTER_PROMETHEUS_OPERATOR_SERVICE_ACCOUNT
+                  value: prometheus-k8s
+                - name: METRICS_EXPORTER_PORT
+                  value: "9110"
                 - name: NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -541,6 +556,7 @@ spec:
           - monitoring.coreos.com
           resources:
           - servicemonitors
+          - prometheusrules
           verbs:
           - get
           - create


### PR DESCRIPTION
Update ClusterServiceVersion with the new permissions and environment variables.

Add `operatorframework.io/cluster-monitoring: true` annotation to make the operator namespace be watched by the monitoring stack, when installing via web console.