### PR TITLE
OCPBUGS-37585: Do not create default pool CR

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,10 +35,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -250,12 +248,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = createDefaultPoolConfig(kubeClient)
-	if err != nil {
-		setupLog.Error(err, "unable to create default SriovNetworkPoolConfig")
-		os.Exit(1)
-	}
-
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
@@ -286,33 +278,6 @@ func main() {
 func initNicIDMap() error {
 	kubeclient := kubernetes.NewForConfigOrDie(ctrl.GetConfigOrDie())
 	if err := sriovnetworkv1.InitNicIDMapFromConfigMap(kubeclient, vars.Namespace); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func createDefaultPoolConfig(c client.Client) error {
-	logger := setupLog.WithName("createDefaultOperatorConfig")
-
-	config := &sriovnetworkv1.SriovNetworkPoolConfig{}
-	err := c.Get(context.TODO(), types.NamespacedName{Name: consts.DefaultConfigName, Namespace: vars.Namespace}, config)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			logger.Info("Create default SriovNetworkPoolConfig")
-			config.Namespace = vars.Namespace
-			config.Name = consts.DefaultConfigName
-			maxun := intstr.Parse("1")
-			config.Spec = sriovnetworkv1.SriovNetworkPoolConfigSpec{
-				MaxUnavailable: &maxun,
-				NodeSelector:   &metav1.LabelSelector{},
-			}
-			err = c.Create(context.TODO(), config)
-			if err != nil {
-				return err
-			}
-		}
-		// Error reading the object - requeue the request.
 		return err
 	}
 


### PR DESCRIPTION
There is no need to create default pool the operator handles that.

This was a left over on the feature parity backport