### PR TITLE
OCPBUGS-38010: [release-4.16]: Skip firmware reset on devices the operator doesn't control

### DIFF
--- a/pkg/helper/mock/mock_helper.go
+++ b/pkg/helper/mock/mock_helper.go
@@ -929,6 +929,20 @@ func (mr *MockHostHelpersInterfaceMockRecorder) RemovePersistPFNameUdevRule(pfPc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePersistPFNameUdevRule", reflect.TypeOf((*MockHostHelpersInterface)(nil).RemovePersistPFNameUdevRule), pfPciAddress)
 }
 
+// RemovePfAppliedStatus mocks base method.
+func (m *MockHostHelpersInterface) RemovePfAppliedStatus(pciAddress string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemovePfAppliedStatus", pciAddress)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemovePfAppliedStatus indicates an expected call of RemovePfAppliedStatus.
+func (mr *MockHostHelpersInterfaceMockRecorder) RemovePfAppliedStatus(pciAddress interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePfAppliedStatus", reflect.TypeOf((*MockHostHelpersInterface)(nil).RemovePfAppliedStatus), pciAddress)
+}
+
 // RemoveVfRepresentorUdevRule mocks base method.
 func (m *MockHostHelpersInterface) RemoveVfRepresentorUdevRule(pfPciAddress string) error {
 	m.ctrl.T.Helper()

--- a/pkg/host/internal/sriov/sriov.go
+++ b/pkg/host/internal/sriov/sriov.go
@@ -798,6 +798,13 @@ func (s *sriov) checkForConfigAndReset(ifaceStatus sriovnetworkv1.InterfaceExt, 
 		log.Log.V(2).Info("checkForConfigAndReset(): PF name with pci address was externally created skipping the device reset",
 			"pf-name", ifaceStatus.Name,
 			"address", ifaceStatus.PciAddress)
+
+		// remove pf status from host
+		err = storeManager.RemovePfAppliedStatus(ifaceStatus.PciAddress)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	}
 	err = s.removeUdevRules(ifaceStatus.PciAddress)
@@ -806,6 +813,12 @@ func (s *sriov) checkForConfigAndReset(ifaceStatus sriovnetworkv1.InterfaceExt, 
 	}
 
 	if err = s.ResetSriovDevice(ifaceStatus); err != nil {
+		return err
+	}
+
+	// remove pf status from host
+	err = storeManager.RemovePfAppliedStatus(ifaceStatus.PciAddress)
+	if err != nil {
 		return err
 	}
 

--- a/pkg/host/internal/sriov/sriov_test.go
+++ b/pkg/host/internal/sriov/sriov_test.go
@@ -347,6 +347,7 @@ var _ = Describe("SRIOV", func() {
 				PciAddress: "0000:d8:00.0",
 				NumVfs:     2,
 			}, true, nil)
+			storeManagerMode.EXPECT().RemovePfAppliedStatus("0000:d8:00.0").Return(nil)
 			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(
 				&netlink.DevlinkDevice{Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}},
 				nil)
@@ -374,6 +375,7 @@ var _ = Describe("SRIOV", func() {
 				NumVfs:            2,
 				ExternallyManaged: true,
 			}, true, nil)
+			storeManagerMode.EXPECT().RemovePfAppliedStatus("0000:d8:00.0").Return(nil)
 			Expect(s.ConfigSriovInterfaces(storeManagerMode,
 				[]sriovnetworkv1.Interface{},
 				[]sriovnetworkv1.InterfaceExt{

--- a/pkg/host/store/mock/mock_store.go
+++ b/pkg/host/store/mock/mock_store.go
@@ -79,6 +79,20 @@ func (mr *MockManagerInterfaceMockRecorder) LoadPfsStatus(pciAddress interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadPfsStatus", reflect.TypeOf((*MockManagerInterface)(nil).LoadPfsStatus), pciAddress)
 }
 
+// RemovePfAppliedStatus mocks base method.
+func (m *MockManagerInterface) RemovePfAppliedStatus(pciAddress string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemovePfAppliedStatus", pciAddress)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemovePfAppliedStatus indicates an expected call of RemovePfAppliedStatus.
+func (mr *MockManagerInterfaceMockRecorder) RemovePfAppliedStatus(pciAddress interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePfAppliedStatus", reflect.TypeOf((*MockManagerInterface)(nil).RemovePfAppliedStatus), pciAddress)
+}
+
 // SaveLastPfAppliedStatus mocks base method.
 func (m *MockManagerInterface) SaveLastPfAppliedStatus(PfInfo *v1.Interface) error {
 	m.ctrl.T.Helper()

--- a/pkg/host/store/store.go
+++ b/pkg/host/store/store.go
@@ -20,6 +20,7 @@ import (
 type ManagerInterface interface {
 	ClearPCIAddressFolder() error
 	SaveLastPfAppliedStatus(PfInfo *sriovnetworkv1.Interface) error
+	RemovePfAppliedStatus(pciAddress string) error
 	LoadPfsStatus(pciAddress string) (*sriovnetworkv1.Interface, bool, error)
 
 	GetCheckPointNodeState() (*sriovnetworkv1.SriovNetworkNodeState, error)
@@ -109,6 +110,17 @@ func (s *manager) SaveLastPfAppliedStatus(PfInfo *sriovnetworkv1.Interface) erro
 	pathFile := filepath.Join(hostExtension, consts.PfAppliedConfig, PfInfo.PciAddress)
 	err = os.WriteFile(pathFile, data, 0644)
 	return err
+}
+
+func (s *manager) RemovePfAppliedStatus(pciAddress string) error {
+	hostExtension := utils.GetHostExtension()
+	pathFile := filepath.Join(hostExtension, consts.PfAppliedConfig, pciAddress)
+	err := os.RemoveAll(pathFile)
+	if err != nil {
+		log.Log.Error(err, "failed to remove PF status", "pathFile", pathFile)
+		return err
+	}
+	return nil
 }
 
 // LoadPfsStatus convert the /etc/sriov-operator/pci/<pci-address> json to pfstatus


### PR DESCRIPTION
4.16 Backport of
- https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/734
- https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/743

no conflicts

This should fix the failing test
```
[It] [sriov] operator Custom SriovNetworkNodePolicy ExternallyManaged Validation Should create a policy if the number of requested vfs is equal and not delete them when the policy is removed
```

cc @SchSeba 


