### PR TITLE
Bump 4.18

### DIFF
--- a/Makefile.bundle
+++ b/Makefile.bundle
@@ -1,6 +1,6 @@
 include Makefile
 # Current Operator version
-VERSION ?= 4.17.0
+VERSION ?= 4.18.0
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,7 +33,7 @@ spec:
         operator: Exists
       containers:
       - name: sriov-network-operator
-        image: quay.io/openshift/origin-sriov-network-operator:4.17
+        image: quay.io/openshift/origin-sriov-network-operator:4.18
         command:
         - sriov-network-operator
         args:
@@ -60,21 +60,21 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: SRIOV_CNI_IMAGE
-            value: quay.io/openshift/origin-sriov-cni:4.17
+            value: quay.io/openshift/origin-sriov-cni:4.18
           - name: SRIOV_DEVICE_PLUGIN_IMAGE
-            value: quay.io/openshift/origin-sriov-network-device-plugin:4.17
+            value: quay.io/openshift/origin-sriov-network-device-plugin:4.18
           - name: NETWORK_RESOURCES_INJECTOR_IMAGE
-            value: quay.io/openshift/origin-sriov-dp-admission-controller:4.17
+            value: quay.io/openshift/origin-sriov-dp-admission-controller:4.18
           - name: OPERATOR_NAME
             value: sriov-network-operator
           - name: SRIOV_NETWORK_CONFIG_DAEMON_IMAGE
-            value: quay.io/openshift/origin-sriov-network-config-daemon:4.17
+            value: quay.io/openshift/origin-sriov-network-config-daemon:4.18
           - name: SRIOV_NETWORK_WEBHOOK_IMAGE
-            value: quay.io/openshift/origin-sriov-network-webhook:4.17
+            value: quay.io/openshift/origin-sriov-network-webhook:4.18
           - name: SRIOV_INFINIBAND_CNI_IMAGE
-            value: quay.io/openshift/origin-sriov-infiniband-cni:4.17
+            value: quay.io/openshift/origin-sriov-infiniband-cni:4.18
           - name: RDMA_CNI_IMAGE
-            value: quay.io/openshift/origin-rdma-cni:4.17
+            value: quay.io/openshift/origin-rdma-cni:4.18
           - name: RESOURCE_PREFIX
             value: openshift.io
           - name: ADMISSION_CONTROLLERS_ENABLED
@@ -84,9 +84,9 @@ spec:
           - name: ADMISSION_CONTROLLERS_CERTIFICATES_INJECTOR_SECRET_NAME
             value: network-resources-injector-secret
           - name: METRICS_EXPORTER_IMAGE
-            value: quay.io/openshift/origin-sriov-network-metrics-exporter:4.17
+            value: quay.io/openshift/origin-sriov-network-metrics-exporter:4.18
           - name: METRICS_EXPORTER_KUBE_RBAC_PROXY_IMAGE
-            value: quay.io/openshift/origin-kube-rbac-proxy:4.17
+            value: quay.io/openshift/origin-kube-rbac-proxy:4.18
           - name: METRICS_EXPORTER_SECRET_NAME
             value: metrics-exporter-cert
           - name: METRICS_EXPORTER_PROMETHEUS_OPERATOR_ENABLED
@@ -110,4 +110,4 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
           - name: RELEASE_VERSION
-            value: 4.17.0
+            value: 4.18.0

--- a/config/manifests/bases/sriov-network-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sriov-network-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/openshift/origin-sriov-network-operator:4.17
+    containerImage: quay.io/openshift/origin-sriov-network-operator:4.18
     createdAt: 2019/04/30
     description: An operator for configuring SR-IOV components and initializing SRIOV
       network devices in Openshift cluster.
@@ -20,7 +20,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.3.0-0 <4.17.0'
+    olm.skipRange: '>=4.3.0-0 <4.18.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/initialization-resource: |-
       {
@@ -147,7 +147,7 @@ spec:
   - sriov
   labels:
     olm-owner-enterprise-app: sriov-network-operator
-    olm-status-descriptors: sriov-network-operator.v4.17.0
+    olm-status-descriptors: sriov-network-operator.v4.18.0
   links:
   - name: Source Code
     url: https://github.com/k8snetworkplumbingwg/sriov-network-operator
@@ -156,4 +156,4 @@ spec:
     name: Red Hat
   provider:
     name: Red Hat
-  version: 4.17.0
+  version: 4.18.0

--- a/manifests/sriov-network-operator.package.yaml
+++ b/manifests/sriov-network-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: sriov-network-operator
 channels:
 - name: "stable"
-  currentCSV: sriov-network-operator.v4.17.0
+  currentCSV: sriov-network-operator.v4.18.0

--- a/manifests/stable/image-references
+++ b/manifests/stable/image-references
@@ -6,41 +6,41 @@ spec:
   - name: sriov-network-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sriov-network-operator:4.17
+      name: quay.io/openshift/origin-sriov-network-operator:4.18
   - name: sriov-network-config-daemon
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sriov-network-config-daemon:4.17
+      name: quay.io/openshift/origin-sriov-network-config-daemon:4.18
   - name: sriov-cni
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sriov-cni:4.17
+      name: quay.io/openshift/origin-sriov-cni:4.18
   - name: sriov-network-device-plugin
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sriov-network-device-plugin:4.17
+      name: quay.io/openshift/origin-sriov-network-device-plugin:4.18
   - name: sriov-dp-admission-controller
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sriov-dp-admission-controller:4.17
+      name: quay.io/openshift/origin-sriov-dp-admission-controller:4.18
   - name: sriov-network-webhook
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sriov-network-webhook:4.17
+      name: quay.io/openshift/origin-sriov-network-webhook:4.18
   - name: sriov-infiniband-cni
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sriov-infiniband-cni:4.17
+      name: quay.io/openshift/origin-sriov-infiniband-cni:4.18
   - name: rdma-cni
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-rdma-cni:4.17
+      name: quay.io/openshift/origin-rdma-cni:4.18
   - name: sriov-network-metrics-exporter
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-sriov-network-metrics-exporter:4.17
+      name: quay.io/openshift/origin-sriov-network-metrics-exporter:4.18
   - name: kube-rbac-proxy
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-kube-rbac-proxy:4.17      
+      name: quay.io/openshift/origin-kube-rbac-proxy:4.18      
 

--- a/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
+++ b/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/openshift/origin-sriov-network-operator:4.17
+    containerImage: quay.io/openshift/origin-sriov-network-operator:4.18
     createdAt: "2024-08-05T23:49:14Z"
     description: An operator for configuring SR-IOV components and initializing SRIOV
       network devices in Openshift cluster.
@@ -113,7 +113,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.3.0-0 <4.17.0'
+    olm.skipRange: '>=4.3.0-0 <4.18.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/initialization-resource: |-
       {
@@ -151,7 +151,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
-  name: sriov-network-operator.v4.17.0
+  name: sriov-network-operator.v4.18.0
   namespace: openshift-sriov-network-operator
 spec:
   apiservicedefinitions: {}
@@ -372,21 +372,21 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: SRIOV_CNI_IMAGE
-                  value: quay.io/openshift/origin-sriov-cni:4.17
+                  value: quay.io/openshift/origin-sriov-cni:4.18
                 - name: SRIOV_DEVICE_PLUGIN_IMAGE
-                  value: quay.io/openshift/origin-sriov-network-device-plugin:4.17
+                  value: quay.io/openshift/origin-sriov-network-device-plugin:4.18
                 - name: NETWORK_RESOURCES_INJECTOR_IMAGE
-                  value: quay.io/openshift/origin-sriov-dp-admission-controller:4.17
+                  value: quay.io/openshift/origin-sriov-dp-admission-controller:4.18
                 - name: OPERATOR_NAME
                   value: sriov-network-operator
                 - name: SRIOV_NETWORK_CONFIG_DAEMON_IMAGE
-                  value: quay.io/openshift/origin-sriov-network-config-daemon:4.17
+                  value: quay.io/openshift/origin-sriov-network-config-daemon:4.18
                 - name: SRIOV_NETWORK_WEBHOOK_IMAGE
-                  value: quay.io/openshift/origin-sriov-network-webhook:4.17
+                  value: quay.io/openshift/origin-sriov-network-webhook:4.18
                 - name: SRIOV_INFINIBAND_CNI_IMAGE
-                  value: quay.io/openshift/origin-sriov-infiniband-cni:4.17
+                  value: quay.io/openshift/origin-sriov-infiniband-cni:4.18
                 - name: RDMA_CNI_IMAGE
-                  value: quay.io/openshift/origin-rdma-cni:4.17
+                  value: quay.io/openshift/origin-rdma-cni:4.18
                 - name: RESOURCE_PREFIX
                   value: openshift.io
                 - name: ADMISSION_CONTROLLERS_ENABLED
@@ -396,9 +396,9 @@ spec:
                 - name: ADMISSION_CONTROLLERS_CERTIFICATES_INJECTOR_SECRET_NAME
                   value: network-resources-injector-secret
                 - name: METRICS_EXPORTER_IMAGE
-                  value: quay.io/openshift/origin-sriov-network-metrics-exporter:4.17
+                  value: quay.io/openshift/origin-sriov-network-metrics-exporter:4.18
                 - name: METRICS_EXPORTER_KUBE_RBAC_PROXY_IMAGE
-                  value: quay.io/openshift/origin-kube-rbac-proxy:4.17
+                  value: quay.io/openshift/origin-kube-rbac-proxy:4.18
                 - name: METRICS_EXPORTER_SECRET_NAME
                   value: metrics-exporter-cert
                 - name: METRICS_EXPORTER_PROMETHEUS_OPERATOR_ENABLED
@@ -422,8 +422,8 @@ spec:
                     fieldRef:
                       fieldPath: metadata.name
                 - name: RELEASE_VERSION
-                  value: 4.17.0
-                image: quay.io/openshift/origin-sriov-network-operator:4.17
+                  value: 4.18.0
+                image: quay.io/openshift/origin-sriov-network-operator:4.18
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:
@@ -599,7 +599,7 @@ spec:
   - sriov
   labels:
     olm-owner-enterprise-app: sriov-network-operator
-    olm-status-descriptors: sriov-network-operator.v4.17.0
+    olm-status-descriptors: sriov-network-operator.v4.18.0
   links:
   - name: Source Code
     url: https://github.com/k8snetworkplumbingwg/sriov-network-operator
@@ -608,4 +608,4 @@ spec:
     name: Red Hat
   provider:
     name: Red Hat
-  version: 4.17.0
+  version: 4.18.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -10,10 +10,10 @@ import (
 var (
 	// Raw is the string representation of the version. This will be replaced
 	// with the calculated version at build time.
-	Raw = "v4.17.0"
+	Raw = "v4.18.0"
 
 	// Version is semver representation of the version.
-	Version = semver.MustParse("4.17.0")
+	Version = semver.MustParse("4.18.0")
 
 	// String is the human-friendly representation of the version.
 	String = fmt.Sprintf("SriovNetworkConfigOperator %s", Raw)


### PR DESCRIPTION
General version bump for 4.17 -> 4.18 in files:
```
Makefile.bundle
config/manager/manager.yaml
config/manifests/bases/sriov-network-operator.clusterserviceversion.yaml
manifests/sriov-network-operator.package.yaml
manifests/stable/image-references
manifests/stable/sriov-network-operator.clusterserviceversion.yaml
pkg/version/version.go
```