### PR TITLE
OCPBUGS-42252: [release-4.17] Preserve user defined annotations on `SriovNetworks`

### DIFF
--- a/controllers/generic_network_controller.go
+++ b/controllers/generic_network_controller.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/vars"
 )
 
@@ -168,9 +169,9 @@ func (r *genericNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				reqLogger.Error(err, "Couldn't create NetworkAttachmentDefinition CR", "Namespace", netAttDef.Namespace, "Name", netAttDef.Name)
 				return reconcile.Result{}, err
 			}
-			anno := map[string]string{sriovnetworkv1.LASTNETWORKNAMESPACE: netAttDef.Namespace}
-			instance.SetAnnotations(anno)
-			if err := r.Update(ctx, instance); err != nil {
+
+			err = utils.AnnotateObject(ctx, instance, sriovnetworkv1.LASTNETWORKNAMESPACE, netAttDef.Namespace, r.Client)
+			if err != nil {
 				return reconcile.Result{}, err
 			}
 		} else {

--- a/controllers/sriovnetwork_controller_test.go
+++ b/controllers/sriovnetwork_controller_test.go
@@ -314,6 +314,34 @@ var _ = Describe("SriovNetwork Controller", Ordered, func() {
 			})
 		})
 
+		It("should preserve user defined annotations", func() {
+			cr := sriovnetworkv1.SriovNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-annotations",
+					Namespace:   testNamespace,
+					Annotations: map[string]string{"foo": "bar"},
+				},
+				Spec: sriovnetworkv1.SriovNetworkSpec{
+					NetworkNamespace: "default",
+				},
+			}
+
+			err := k8sClient.Create(ctx, &cr)
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(k8sClient.Delete, ctx, &cr)
+
+			Eventually(func(g Gomega) {
+				network := &sriovnetworkv1.SriovNetwork{}
+				err = k8sClient.Get(ctx, types.NamespacedName{Name: cr.GetName(), Namespace: testNamespace}, network)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(network.Annotations).To(HaveKeyWithValue("foo", "bar"))
+				g.Expect(network.Annotations).To(HaveKeyWithValue("operator.sriovnetwork.openshift.io/last-network-namespace", "default"))
+			}).
+				WithPolling(100 * time.Millisecond).
+				WithTimeout(5 * time.Second).
+				MustPassRepeatedly(10).
+				Should(Succeed())
+		})
 	})
 })
 


### PR DESCRIPTION
4.17 backport of:
- https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/775