### PR TITLE
OCPBUGS-42956: [release-4.13] Render SriovNetworkNodeState before Device Plugin ConfigMap

### DIFF
--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -145,16 +145,16 @@ func (r *SriovNetworkNodePolicyReconciler) Reconcile(ctx context.Context, req ct
 
 	// Sort the policies with priority, higher priority ones is applied later
 	sort.Sort(sriovnetworkv1.ByPriority(policyList.Items))
+	// Sync SriovNetworkNodeState objects
+	if err = r.syncAllSriovNetworkNodeStates(ctx, defaultPolicy, policyList, nodeList); err != nil {
+		return reconcile.Result{}, err
+	}
 	// Sync Sriov device plugin ConfigMap object
 	if err = r.syncDevicePluginConfigMap(ctx, policyList, nodeList); err != nil {
 		return reconcile.Result{}, err
 	}
 	// Render and sync Daemon objects
 	if err = r.syncPluginDaemonObjs(ctx, defaultPolicy, policyList); err != nil {
-		return reconcile.Result{}, err
-	}
-	// Sync SriovNetworkNodeState objects
-	if err = r.syncAllSriovNetworkNodeStates(ctx, defaultPolicy, policyList, nodeList); err != nil {
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
4.13 backport of:
- https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/487