### PR TITLE
OCPBUGS-43108: [release-4.17] Delete webhooks when SriovOperatorConfig is deleted

### DIFF
--- a/controllers/sriovoperatorconfig_controller_test.go
+++ b/controllers/sriovoperatorconfig_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	admv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -38,15 +39,7 @@ var _ = Describe("SriovOperatorConfig controller", Ordered, func() {
 
 	BeforeAll(func() {
 		By("Create SriovOperatorConfig controller k8s objs")
-		config := &sriovnetworkv1.SriovOperatorConfig{}
-		config.SetNamespace(testNamespace)
-		config.SetName(consts.DefaultConfigName)
-		config.Spec = sriovnetworkv1.SriovOperatorConfigSpec{
-			EnableInjector:           true,
-			EnableOperatorWebhook:    true,
-			ConfigDaemonNodeSelector: map[string]string{},
-			LogLevel:                 2,
-		}
+		config := makeDefaultSriovOpConfig()
 		Expect(k8sClient.Create(context.Background(), config)).Should(Succeed())
 		DeferCleanup(func() {
 			err := k8sClient.Delete(context.Background(), config)
@@ -222,6 +215,29 @@ var _ = Describe("SriovOperatorConfig controller", Ordered, func() {
 			validateCfg = &admv1.ValidatingWebhookConfiguration{}
 			err = util.WaitForNamespacedObject(validateCfg, k8sClient, testNamespace, "sriov-operator-webhook-config", util.RetryInterval, util.APITimeout)
 			Expect(err).NotTo(HaveOccurred())
+		})
+
+		// Namespaced resources are deleted via the `.ObjectMeta.OwnerReference` field. That logic can't be tested here because testenv doesn't have built-in controllers
+		// (See https://book.kubebuilder.io/reference/envtest#testing-considerations). Since Service and DaemonSet are deleted when default/SriovOperatorConfig is no longer
+		// present, it's important that webhook configurations are deleted as well.
+		It("should delete the webhooks when SriovOperatorConfig/default is deleted", func() {
+			DeferCleanup(k8sClient.Create, context.Background(), makeDefaultSriovOpConfig())
+
+			err := k8sClient.Delete(context.Background(), &sriovnetworkv1.SriovOperatorConfig{
+				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			assertResourceDoesNotExist(
+				schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Kind: "MutatingWebhookConfiguration", Version: "v1"},
+				client.ObjectKey{Name: "sriov-operator-webhook-config"})
+			assertResourceDoesNotExist(
+				schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Kind: "ValidatingWebhookConfiguration", Version: "v1"},
+				client.ObjectKey{Name: "sriov-operator-webhook-config"})
+
+			assertResourceDoesNotExist(
+				schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Kind: "MutatingWebhookConfiguration", Version: "v1"},
+				client.ObjectKey{Name: "network-resources-injector-config"})
 		})
 
 		It("should be able to update the node selector of sriov-network-config-daemon", func() {
@@ -495,9 +511,36 @@ var _ = Describe("SriovOperatorConfig controller", Ordered, func() {
 	})
 })
 
+func makeDefaultSriovOpConfig() *sriovnetworkv1.SriovOperatorConfig {
+	config := &sriovnetworkv1.SriovOperatorConfig{}
+	config.SetNamespace(testNamespace)
+	config.SetName(consts.DefaultConfigName)
+	config.Spec = sriovnetworkv1.SriovOperatorConfigSpec{
+		EnableInjector:           true,
+		EnableOperatorWebhook:    true,
+		ConfigDaemonNodeSelector: map[string]string{},
+		LogLevel:                 2,
+	}
+	return config
+}
+
 func assertResourceExists(gvk schema.GroupVersionKind, key client.ObjectKey) {
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(gvk)
 	err := k8sClient.Get(context.Background(), key, u)
 	Expect(err).NotTo(HaveOccurred())
+}
+
+func assertResourceDoesNotExist(gvk schema.GroupVersionKind, key client.ObjectKey) {
+	Eventually(func(g Gomega) {
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(gvk)
+		err := k8sClient.Get(context.Background(), key, u)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(errors.IsNotFound(err)).To(BeTrue())
+	}).
+		WithOffset(1).
+		WithPolling(100*time.Millisecond).
+		WithTimeout(2*time.Second).
+		Should(Succeed(), "Resource type[%s] name[%s] still present in the cluster", gvk.String(), key.String())
 }

--- a/pkg/host/internal/network/network.go
+++ b/pkg/host/internal/network/network.go
@@ -75,7 +75,7 @@ func (n *network) TryToGetVirtualInterfaceName(pciAddr string) string {
 func (n *network) TryGetInterfaceName(pciAddr string) string {
 	names, err := n.dputilsLib.GetNetNames(pciAddr)
 	if err != nil || len(names) < 1 {
-		log.Log.Error(err, "TryGetInterfaceName(): failed to get interface name")
+		log.Log.Error(err, "TryGetInterfaceName(): failed to get interface name", "pciAddress", pciAddr)
 		return ""
 	}
 	netDevName := names[0]

--- a/pkg/host/internal/vdpa/vdpa.go
+++ b/pkg/host/internal/vdpa/vdpa.go
@@ -94,11 +94,9 @@ func (v *vdpa) DeleteVDPADevice(pciAddr string) error {
 func (v *vdpa) DiscoverVDPAType(pciAddr string) string {
 	expectedVDPAName := generateVDPADevName(pciAddr)
 	funcLog := log.Log.WithValues("device", pciAddr, "name", expectedVDPAName)
-	funcLog.V(2).Info("DiscoverVDPAType() discover device type")
 	_, err := v.netlinkLib.VDPAGetDevByName(expectedVDPAName)
 	if err != nil {
 		if errors.Is(err, syscall.ENODEV) {
-			funcLog.V(2).Info("DiscoverVDPAType(): VDPA device for VF not found")
 			return ""
 		}
 		if errors.Is(err, syscall.ENOENT) {


### PR DESCRIPTION
When a user deletes the default SriovOperatorConfig resource and tries to recreate it afterwards, the operator webhooks returns the error:
```
Error from server (InternalError): error when creating "/tmp/opconfig.yml": Internal error occurred: failed calling webhook "operator-webhook.sriovnetwork.openshift.io": failed to call webhook: Post "https://operator-webhook-service.openshift-sriov-network-operator.svc:443/validating-custom-resource?timeout=10s": service "operator-webhook-service" not found
```

as the webhook configuration is still present, while the Service and the DaemonSet has been deleted.

Delete all the webhook configurations when the user deletes the default SriovOperatorConfig

4.17 backport of
- https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/779