### PR TITLE
OCPBUGS-44515: relax Operator node affinity for Hypershift

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,7 +20,12 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
+          # In the context of Hypershift, the SR-IOV network
+          # Operator is deployed on Nodepools which are labeled
+          # as workers. So we relax the node affinity to prefer
+          # masters/control-plane when possible otherwise we
+          # schedule where it's possible.
+          preferredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
               - key: node-role.kubernetes.io/master


### PR DESCRIPTION
In the context of Hypershift (Hosted Clusters), where a Nodepool
(terminology for a worker Node in HCP) is not a control-plane or
a master Node but a worker, we can't force the

The proposal here is to relax the rule and use
`preferredDuringSchedulingIgnoredDuringExecution` instead so the scheduler
will try to find a master node or fallback on other nodes if not found.