### PR TITLE
[th/deploy-detect-defaults] fix `make deploy-setup` to pass and autodetect some URLs

### DIFF
--- a/hack/env.sh
+++ b/hack/env.sh
@@ -1,35 +1,48 @@
 #!/bin/bash
 
+_url_detect() {
+    local varname="$1"
+    local url="$2"
+    local digest
+    local value=
+
+    if [ "$EMPTY_IS_VALID" = 1 ] ; then
+        [ -n "${!varname+set}" ] && return 0
+    else
+        [ -n "${!varname}" ] && return 0
+    fi
+
+    if [ -n "$url" ] ; then
+        digest="$(skopeo inspect "docker://$url" | jq --raw-output '.Digest')" || :
+        if [ -z "$digest" ] ; then
+            echo "Failure to detect \$$varname at $url. Set the variable"
+            return 1
+        fi
+        value="$url@$digest"
+    fi
+
+    export "$varname=$value"
+}
+
 if [ -z $SKIP_VAR_SET ]; then
         if ! skopeo -v &> /dev/null
         then
                 echo "skopeo could not be found"
                 exit 1
         fi
-        CNI_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/openshift/origin-sriov-cni | jq --raw-output '.Digest')
-        export SRIOV_CNI_IMAGE=${SRIOV_CNI_IMAGE:-quay.io/openshift/origin-sriov-cni@${CNI_IMAGE_DIGEST}}
-        INFINIBAND_CNI_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/openshift/origin-sriov-infiniband-cni | jq --raw-output '.Digest')
-        export SRIOV_INFINIBAND_CNI_IMAGE=${SRIOV_INFINIBAND_CNI_IMAGE:-quay.io/openshift/origin-sriov-infiniband-cni@${INFINIBAND_CNI_IMAGE_DIGEST}}
-        # OVS_CNI_IMAGE can be explicitly set to empty value, use default only if the var is not set
-        OVS_CNI_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/kubevirt/ovs-cni-plugin | jq --raw-output '.Digest')
-        export OVS_CNI_IMAGE=${OVS_CNI_IMAGE:-quay.io/kubevirt/ovs-cni-plugin@${OVS_CNI_IMAGE_DIGEST}}
-        # RDMA_CNI_IMAGE can be explicitly set to empty value, use default only if the var is not set
-        RDMA_CNI_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/openshift/origin-rdma-cni | jq --raw-output '.Digest')
-        export RDMA_CNI_IMAGE=${RDMA_CNI_IMAGE-quay.io/openshift/origin-rdma-cni@${RDMA_CNI_IMAGE_DIGEST}}
-        DP_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/openshift/origin-sriov-network-device-plugin | jq --raw-output '.Digest')
-        export SRIOV_DEVICE_PLUGIN_IMAGE=${SRIOV_DEVICE_PLUGIN_IMAGE:-quay.io/openshift/origin-sriov-network-device-plugin@${DP_IMAGE_DIGEST}}
-        INJECTOR_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/openshift/origin-sriov-dp-admission-controller | jq --raw-output '.Digest')
-        export NETWORK_RESOURCES_INJECTOR_IMAGE=${NETWORK_RESOURCES_INJECTOR_IMAGE:-quay.io/openshift/origin-sriov-dp-admission-controller@${INJECTOR_IMAGE_DIGEST}}
-        DAEMON_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/openshift/origin-sriov-network-config-daemon | jq --raw-output '.Digest')
-        export SRIOV_NETWORK_CONFIG_DAEMON_IMAGE=${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE:-quay.io/openshift/origin-sriov-network-config-daemon@${DAEMON_IMAGE_DIGEST}}
-        WEBHOOK_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/openshift/origin-sriov-network-webhook | jq --raw-output '.Digest')
-        export SRIOV_NETWORK_WEBHOOK_IMAGE=${SRIOV_NETWORK_WEBHOOK_IMAGE:-quay.io/openshift/origin-sriov-network-webhook@${WEBHOOK_IMAGE_DIGEST}}
-        METRICS_EXPORTER_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/openshift/origin-sriov-network-metrics-exporter | jq --raw-output '.Digest')
-        export METRICS_EXPORTER_IMAGE=${METRICS_EXPORTER_IMAGE:-quay.io/openshift/origin-sriov-network-metrics-exporter@${METRICS_EXPORTER_IMAGE_DIGEST}}
-        OPERATOR_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/openshift/origin-sriov-network-operator | jq --raw-output '.Digest')
-        export SRIOV_NETWORK_OPERATOR_IMAGE=${SRIOV_NETWORK_OPERATOR_IMAGE:-quay.io/openshift/origin-sriov-network-operator@${OPERATOR_IMAGE_DIGEST}}
-        METRICS_EXPORTER_KUBE_RBAC_PROXY_IMAGE_DIGEST=$(skopeo inspect docker://quay.io/openshift/origin-kube-rbac-proxy | jq --raw-output '.Digest')
-        export METRICS_EXPORTER_KUBE_RBAC_PROXY_IMAGE=${METRICS_EXPORTER_KUBE_RBAC_PROXY_IMAGE:-quay.io/openshift/origin-kube-rbac-proxy@${METRICS_EXPORTER_KUBE_RBAC_PROXY_IMAGE_DIGEST}}
+
+        _url_detect "SRIOV_CNI_IMAGE" "quay.io/openshift/origin-sriov-cni"
+        _url_detect "SRIOV_INFINIBAND_CNI_IMAGE" "quay.io/openshift/origin-sriov-infiniband-cni"
+        EMPTY_IS_VALID=1 _url_detect "OVS_CNI_IMAGE" "quay.io/kubevirt/ovs-cni-plugin"
+        EMPTY_IS_VALID=1 _url_detect "RDMA_CNI_IMAGE" "quay.io/openshift/origin-rdma-cni"
+        _url_detect "SRIOV_DEVICE_PLUGIN_IMAGE" "quay.io/openshift/origin-sriov-network-device-plugin"
+        _url_detect "NETWORK_RESOURCES_INJECTOR_IMAGE" "quay.io/openshift/origin-sriov-dp-admission-controller"
+        _url_detect "SRIOV_NETWORK_CONFIG_DAEMON_IMAGE" "quay.io/openshift/origin-sriov-network-config-daemon"
+        _url_detect "SRIOV_NETWORK_WEBHOOK_IMAGE" "quay.io/openshift/origin-sriov-network-webhook"
+        _url_detect "METRICS_EXPORTER_IMAGE" "quay.io/openshift/origin-sriov-network-metrics-exporter"
+        _url_detect "SRIOV_NETWORK_OPERATOR_IMAGE" "quay.io/openshift/origin-sriov-network-operator"
+        EMPTY_IS_VALID=1 _url_detect "METRICS_EXPORTER_KUBE_RBAC_PROXY_IMAGE" "quay.io/openshift/origin-kube-rbac-proxy"
+
         fail_msg_detect="is empty and failed to detect"
 else
         fail_msg_detect="is empty but SKIP_VAR_SET is set"


### PR DESCRIPTION
Currently, `make deploy-setup` fails unless we set `$SKIP_VAR_SET`.

Quote commit message:

---

hack/env.sh: fix detecting default values for images

Note that most of quay.io repositories (not all of them) are depublished
and the detection no longer works:

    FATA[0001] Error parsing image name "docker://quay.io/openshift/origin-sriov-cni": reading manifest latest in quay.io/openshift/origin-sriov-cni: unauthorized: access to the requested resource is not authorized

Together that with [1],  the calling shell scripts now `set -e`, which
exits the script in such errors.

This means, `make deploy-setup` fails unless $SKIP_VAR_SET is set. That
is even if the caller *did* set the missing environment variables for
the images. Note that doing that is not useless, because while several
quay.io repositories no longer exist, others like [2] still do.  So you
can set the ones we must, don't set $SKIP_VAR_SET, and let the others be
detected as in the past.

Fix this by reworking the detection.

The patch does not change URLs like "quay.io/openshift/origin-sriov-cni"
because there is no better default. If the caller doesn't set the
environment variables like SRIOV_CNI_IMAGE, then deploy is going to fail
either way.

[1] 624a16feb327 ('Let "depoly-setup.sh" and "undeploy.sh" fail on error')
[2] https://quay.io/openshift/origin-kube-rbac-proxy
