### PR TITLE
OCPBUGS-56215: Enable ARM architecture for the operator bundle

### DIFF
--- a/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
@@ -150,6 +150,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
   name: sriov-network-operator.v4.19.0
   namespace: openshift-sriov-network-operator

--- a/config/manifests/bases/sriov-network-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sriov-network-operator.clusterserviceversion.yaml
@@ -55,6 +55,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
   name: sriov-network-operator.v0.0.0
   namespace: openshift-sriov-network-operator

--- a/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
+++ b/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
@@ -150,6 +150,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
   name: sriov-network-operator.v4.19.0
   namespace: openshift-sriov-network-operator


### PR DESCRIPTION
Following https://olm.operatorframework.io/docs/advanced-tasks/ship-operator-supporting-multiarch/ to add the ARM target architecture.