### PR TITLE
OCPBUGS-59290: [release-4.18] kernel: Avoid setting iommu.passthrough on ARM system

### DIFF
--- a/pkg/consts/constants.go
+++ b/pkg/consts/constants.go
@@ -128,12 +128,11 @@ const (
 		`IMPORT{program}="/etc/udev/switchdev-vf-link-name.sh $attr{phys_port_name}", ` +
 		`NAME="%s_$env{NUMBER}"`
 
-	KernelArgPciRealloc       = "pci=realloc"
-	KernelArgIntelIommu       = "intel_iommu=on"
-	KernelArgIommuPt          = "iommu=pt"
-	KernelArgIommuPassthrough = "iommu.passthrough=1"
-	KernelArgRdmaShared       = "ib_core.netns_mode=1"
-	KernelArgRdmaExclusive    = "ib_core.netns_mode=0"
+	KernelArgPciRealloc    = "pci=realloc"
+	KernelArgIntelIommu    = "intel_iommu=on"
+	KernelArgIommuPt       = "iommu=pt"
+	KernelArgRdmaShared    = "ib_core.netns_mode=1"
+	KernelArgRdmaExclusive = "ib_core.netns_mode=0"
 
 	// Feature gates
 	// ParallelNicConfigFeatureGate: allow to configure nics in parallel

--- a/pkg/daemon/plugin_test.go
+++ b/pkg/daemon/plugin_test.go
@@ -47,7 +47,6 @@ var _ = Describe("config daemon plugin loading tests", func() {
 			helperMock.EXPECT().IsKernelArgsSet("", consts.KernelArgPciRealloc).Return(false)
 			helperMock.EXPECT().IsKernelArgsSet("", consts.KernelArgRdmaExclusive).Return(false)
 			helperMock.EXPECT().IsKernelArgsSet("", consts.KernelArgRdmaShared).Return(false)
-			helperMock.EXPECT().IsKernelArgsSet("", consts.KernelArgIommuPassthrough).Return(false)
 
 			// k8s plugin is ATM the only plugin which require mocking/faking, as its New method performs additional logic
 			// other than simple plugin struct initialization

--- a/pkg/plugins/generic/generic_plugin.go
+++ b/pkg/plugins/generic/generic_plugin.go
@@ -119,12 +119,11 @@ func NewGenericPlugin(helpers helper.HostHelpersInterface, options ...Option) (p
 		return nil, err
 	}
 	desiredKernelArgs := KargStateMapType{
-		consts.KernelArgPciRealloc:       helpers.IsKernelArgsSet(kargs, consts.KernelArgPciRealloc),
-		consts.KernelArgIntelIommu:       helpers.IsKernelArgsSet(kargs, consts.KernelArgIntelIommu),
-		consts.KernelArgIommuPt:          helpers.IsKernelArgsSet(kargs, consts.KernelArgIommuPt),
-		consts.KernelArgIommuPassthrough: helpers.IsKernelArgsSet(kargs, consts.KernelArgIommuPassthrough),
-		consts.KernelArgRdmaShared:       false,
-		consts.KernelArgRdmaExclusive:    false,
+		consts.KernelArgPciRealloc:    helpers.IsKernelArgsSet(kargs, consts.KernelArgPciRealloc),
+		consts.KernelArgIntelIommu:    helpers.IsKernelArgsSet(kargs, consts.KernelArgIntelIommu),
+		consts.KernelArgIommuPt:       helpers.IsKernelArgsSet(kargs, consts.KernelArgIommuPt),
+		consts.KernelArgRdmaShared:    false,
+		consts.KernelArgRdmaExclusive: false,
 	}
 
 	return &GenericPlugin{
@@ -437,9 +436,6 @@ func (p *GenericPlugin) addVfioDesiredKernelArg(state *sriovnetworkv1.SriovNetwo
 		},
 		hostTypes.CPUVendorAMD: func() {
 			p.enableDesiredKernelArgs(consts.KernelArgIommuPt)
-		},
-		hostTypes.CPUVendorARM: func() {
-			p.enableDesiredKernelArgs(consts.KernelArgIommuPassthrough)
 		},
 	}
 

--- a/pkg/plugins/generic/generic_plugin_test.go
+++ b/pkg/plugins/generic/generic_plugin_test.go
@@ -41,7 +41,6 @@ var _ = Describe("Generic plugin", func() {
 		hostHelper.EXPECT().IsKernelArgsSet("", consts.KernelArgPciRealloc).Return(false).AnyTimes()
 		hostHelper.EXPECT().IsKernelArgsSet("", consts.KernelArgRdmaExclusive).Return(false).AnyTimes()
 		hostHelper.EXPECT().IsKernelArgsSet("", consts.KernelArgRdmaShared).Return(false).AnyTimes()
-		hostHelper.EXPECT().IsKernelArgsSet("", consts.KernelArgIommuPassthrough).Return(false).AnyTimes()
 
 		hostHelper.EXPECT().RunCommand(gomock.Any(), gomock.Any()).Return("", "", nil).AnyTimes()
 
@@ -933,12 +932,6 @@ var _ = Describe("Generic plugin", func() {
 				hostHelper.EXPECT().GetCPUVendor().Return(hostTypes.CPUVendorAMD, nil)
 				genericPlugin.(*GenericPlugin).addVfioDesiredKernelArg(vfioNetworkNodeState)
 				Expect(genericPlugin.(*GenericPlugin).DesiredKernelArgs[consts.KernelArgIommuPt]).To(BeTrue())
-			})
-
-			It("should set the correct kernel args on ARM CPUs", func() {
-				hostHelper.EXPECT().GetCPUVendor().Return(hostTypes.CPUVendorARM, nil)
-				genericPlugin.(*GenericPlugin).addVfioDesiredKernelArg(vfioNetworkNodeState)
-				Expect(genericPlugin.(*GenericPlugin).DesiredKernelArgs[consts.KernelArgIommuPassthrough]).To(BeTrue())
 			})
 
 			It("should enable rdma shared mode", func() {


### PR DESCRIPTION
The kernel argument `iommu.passthgouh` can break some GPU scenarios when set to `1` [1]:

 >  We recommend that you add the iommu.passthrough=0 kernel parameter until this
issue is resolved

Avoid set the argument, as it would be hard for the user to undone the effect of this operation, as the config-daemon would reconcile the parameter list.

[1] https://docs.nvidia.com/grace-linux-install-guide.pdf