### PR TITLE
CNF-17884: Add RBAC permissions for network policies in SR-IOV operator

### DIFF
--- a/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
@@ -556,6 +556,15 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - get
+          - create
+          - update
+          - delete
+        - apiGroups:
           - monitoring.coreos.com
           resources:
           - servicemonitors

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -26,6 +26,15 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+    - networking.k8s.io
+  resources:
+    - networkpolicies
+  verbs:
+    - get
+    - create
+    - update
+    - delete
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors

--- a/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
+++ b/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
@@ -556,6 +556,15 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - get
+          - create
+          - update
+          - delete
+        - apiGroups:
           - monitoring.coreos.com
           resources:
           - servicemonitors


### PR DESCRIPTION
This update introduces new rules in the RBAC configuration to allow the SR-IOV operator to manage network policies.

Needed for:
- https://github.com/openshift/sriov-network-operator/pull/1112