### PR TITLE
Add ocp-sustaining team members to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,6 +10,8 @@ reviewers:
   - wizhaoredhat
   - SalDaniele
   - zeeke
+  - yash2189
+  - kunalmemane
 approvers:
   - pliurh
   - zshi-redhat
@@ -23,5 +25,7 @@ approvers:
   - wizhaoredhat
   - SalDaniele
   - zeeke
+  - yash2189
+  - kunalmemane
 component: "Networking"
 subcomponent: "SR-IOV"


### PR DESCRIPTION
Add yash and kunal from ocp-sustaining team to OWNERS for having permissions to review/approve EUS releases related PRs