### PR TITLE
OCPBUGS-78767 [release-4.21]: fix: add timeout to sysfs writes to prevent daemon hang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ kustomize: ## Download kustomize locally if necessary.
 
 ENVTEST = $(BIN_DIR)/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.16)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.20)
 
 GOMOCK = $(shell pwd)/bin/mockgen
 gomock:

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	go.uber.org/mock v0.5.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/net v0.38.0
+	golang.org/x/sys v0.31.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.32.1
@@ -155,7 +156,6 @@ require (
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/term v0.30.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/time v0.9.0 // indirect

--- a/pkg/host/internal/sriov/sriov.go
+++ b/pkg/host/internal/sriov/sriov.go
@@ -27,6 +27,12 @@ import (
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/vars"
 )
 
+const (
+	// sysfsWriteTimeout is the timeout for writing to sysfs files (e.g. sriov_numvfs).
+	// Kernel drivers can block indefinitely on these writes if the device is in a bad state.
+	sysfsWriteTimeout = 2 * time.Minute
+)
+
 type interfaceToConfigure struct {
 	iface       sriovnetworkv1.Interface
 	ifaceStatus sriovnetworkv1.InterfaceExt
@@ -75,7 +81,7 @@ func (s *sriov) SetSriovNumVfs(pciAddr string, numVfs int) error {
 	log.Log.V(2).Info("SetSriovNumVfs(): set NumVfs", "device", pciAddr, "numVfs", numVfs)
 	numVfsFilePath := filepath.Join(vars.FilesystemRoot, consts.SysBusPciDevices, pciAddr, consts.NumVfsFile)
 	bs := []byte(strconv.Itoa(numVfs))
-	err := os.WriteFile(numVfsFilePath, []byte("0"), os.ModeAppend)
+	err := utils.WriteFileWithTimeout(numVfsFilePath, []byte("0"), os.ModeAppend, sysfsWriteTimeout)
 	if err != nil {
 		log.Log.Error(err, "SetSriovNumVfs(): fail to reset NumVfs file", "path", numVfsFilePath)
 		return err
@@ -83,7 +89,7 @@ func (s *sriov) SetSriovNumVfs(pciAddr string, numVfs int) error {
 	if numVfs == 0 {
 		return nil
 	}
-	err = os.WriteFile(numVfsFilePath, bs, os.ModeAppend)
+	err = utils.WriteFileWithTimeout(numVfsFilePath, bs, os.ModeAppend, sysfsWriteTimeout)
 	if err != nil {
 		log.Log.Error(err, "SetSriovNumVfs(): fail to set NumVfs file", "path", numVfsFilePath)
 		return err

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -129,3 +129,23 @@ func GetChrootExtension() string {
 	}
 	return fmt.Sprintf("chroot %s%s", vars.FilesystemRoot, consts.Host)
 }
+
+// WriteFileWithTimeout writes data to a file with a timeout.
+// This is useful for writing to sysfs files where the kernel driver may block
+// indefinitely if it is in a bad state.
+// Note: if the timeout expires, the write goroutine will remain blocked in the
+// kernel; it cannot be canceled but will be cleaned up when the process exits.
+func WriteFileWithTimeout(path string, data []byte, perm os.FileMode, timeout time.Duration) error {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ch := make(chan error, 1)
+	go func() {
+		ch <- os.WriteFile(path, data, perm)
+	}()
+	select {
+	case err := <-ch:
+		return err
+	case <-timer.C:
+		return fmt.Errorf("timeout writing to file %s after %v", path, timeout)
+	}
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+)
+
+func TestWriteFileWithTimeout_Success(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "test")
+	data := []byte("hello")
+
+	err := WriteFileWithTimeout(tmpFile, data, 0644, 5*time.Second)
+	assert.NoError(t, err, "expected no error writing file")
+
+	got, err := os.ReadFile(tmpFile)
+	assert.NoError(t, err, "expected no error reading file")
+	assert.Equal(t, data, got, "file contents do not match expected")
+}
+
+func TestWriteFileWithTimeout_WriteError(t *testing.T) {
+	// Writing to a path that doesn't exist should return the underlying error, not a timeout.
+	err := WriteFileWithTimeout("/nonexistent/dir/file", []byte("x"), 0644, 5*time.Second)
+	assert.Error(t, err, "expected error for nonexistent path")
+}
+
+func TestWriteFileWithTimeout_Timeout(t *testing.T) {
+	// A named pipe (FIFO) blocks on open/write until a reader is connected,
+	// which makes it a reliable way to simulate a blocking write.
+	fifoPath := filepath.Join(t.TempDir(), "fifo")
+	assert.NoError(t, unix.Mkfifo(fifoPath, 0600), "failed to create FIFO")
+	defer os.Remove(fifoPath)
+
+	start := time.Now()
+	err := WriteFileWithTimeout(fifoPath, []byte("data"), 0644, 100*time.Millisecond)
+	elapsed := time.Since(start)
+
+	assert.EqualError(t, err, "timeout writing to file "+fifoPath+" after 100ms", "expected timeout error")
+	// The elapsed time should be close to the specified timeout, indicating that the function properly timed out.
+	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond, "function returned too quickly, timeout may not have triggered")
+	assert.Less(t, elapsed, 5*time.Second, "function took too long, timeout did not fire in time")
+}


### PR DESCRIPTION
Kernel drivers (e.g. i40e) can block indefinitely when writing to sriov_numvfs if the device is in a bad state. For example, the following error has been hit on a `Intel XXV710` NIC:

```
Feb 16 13:53:01 worker0 kernel: 06c73374b594186: left promiscuous mode
Feb 16 13:53:01 worker0 kernel: i40e 0000:3b:00.0: Setting MAC 5e:28:32:f0:80:20 on VF 1
Feb 16 13:53:02 worker0 kernel: i40e 0000:3b:00.0: Bring down and up the VF interface to make this change effective.
Feb 16 13:53:02 worker0 kernel: i40e 0000:3b:00.0: Unable to configure VFs, other operation is pending.
Feb 16 13:53:02 worker0 kernel: i40e 0000:3b:00.0: Unable to configure VFs, other operation is pending.
Feb 16 13:53:02 worker0 kernel: 152a5b6a3b44739: left promiscuous mode
```

Replace direct `os.WriteFile` calls in SetSriovNumVfs with a new `WriteFileWithTimeout` utility that runs the write in a goroutine and returns a timeout error after 2 minutes.