### PR TITLE
fix: surface descriptive error when VF creation fails due to MSI-X exhaustion (OCPBUGS-82499)

### DIFF
--- a/pkg/host/internal/sriov/sriov.go
+++ b/pkg/host/internal/sriov/sriov.go
@@ -84,6 +84,12 @@ func (s *sriov) SetSriovNumVfs(pciAddr string, numVfs int) error {
 	bs := []byte(strconv.Itoa(numVfs))
 	err := utils.WriteFileWithTimeout(numVfsFilePath, []byte("0"), os.ModeAppend, sysfsWriteTimeout)
 	if err != nil {
+		var pathErr *os.PathError
+		if errors.As(err, &pathErr) && errors.Is(pathErr.Err, syscall.ENOSPC) {
+			err = fmt.Errorf("insufficient MSI-X vectors available for SR-IOV VF creation on device %s: "+
+				"the system may have exhausted MSI-X interrupt resources (e.g. due to irdma/RDMA driver consuming the budget on high-CPU-count servers). "+
+				"Workaround: blacklist the irdma module (/etc/modprobe.d/) or reduce the number of requested VFs: %w", pciAddr, err)
+		}
 		log.Log.Error(err, "SetSriovNumVfs(): fail to reset NumVfs file", "path", numVfsFilePath)
 		return err
 	}
@@ -92,6 +98,12 @@ func (s *sriov) SetSriovNumVfs(pciAddr string, numVfs int) error {
 	}
 	err = utils.WriteFileWithTimeout(numVfsFilePath, bs, os.ModeAppend, sysfsWriteTimeout)
 	if err != nil {
+		var pathErr *os.PathError
+		if errors.As(err, &pathErr) && errors.Is(pathErr.Err, syscall.ENOSPC) {
+			err = fmt.Errorf("insufficient MSI-X vectors available for SR-IOV VF creation on device %s: "+
+				"the system may have exhausted MSI-X interrupt resources (e.g. due to irdma/RDMA driver consuming the budget on high-CPU-count servers). "+
+				"Workaround: blacklist the irdma module (/etc/modprobe.d/) or reduce the number of requested VFs: %w", pciAddr, err)
+		}
 		log.Log.Error(err, "SetSriovNumVfs(): fail to set NumVfs file", "path", numVfsFilePath)
 		return err
 	}

--- a/pkg/host/internal/sriov/sriov_test.go
+++ b/pkg/host/internal/sriov/sriov_test.go
@@ -1,6 +1,7 @@
 package sriov
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -160,6 +161,22 @@ var _ = Describe("SRIOV", func() {
 		})
 		It("fail - no such device", func() {
 			Expect(s.SetSriovNumVfs("0000:d8:00.0", 5)).To(HaveOccurred())
+		})
+		It("fail - ENOSPC returns descriptive MSI-X error", func() {
+			// Simulate kernel ENOSPC (-28) by symlinking sriov_numvfs to /dev/full,
+			// which always returns ENOSPC on write. This reproduces the Intel E810-xxVDA4
+			// failure mode where irdma exhausts MSI-X vectors on high-CPU-count servers.
+			helpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
+				Dirs: []string{"/sys/bus/pci/devices/0000:d8:00.0"},
+				Symlinks: map[string]string{
+					"/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs": "/dev/full",
+				},
+			})
+			err := s.SetSriovNumVfs("0000:d8:00.0", 5)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("insufficient MSI-X vectors"))
+			Expect(err.Error()).To(ContainSubstring("irdma"))
+			Expect(errors.Is(err, syscall.ENOSPC)).To(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
## Summary

- Detect `ENOSPC` (-28) when writing to `sriov_numvfs` and return a descriptive error message explaining the MSI-X vector exhaustion root cause
- Adds a unit test using `/dev/full` to simulate the kernel ENOSPC condition

## Root Cause

On high-CPU-count servers (256+ CPUs, e.g. Lenovo SR850 V3 with 480 CPUs) equipped with Intel E810-xxVDA4 NICs, the `ice` PF driver and `irdma` RDMA driver together exhaust the MSI-X interrupt vector budget at probe time. The `ice` driver requires a minimum of 2 MSI-X vectors per VF (`ICE_MIN_INTR_PER_VF`), so with 0 vectors remaining, even a single VF creation fails with:

```
Failed to enable SRIOV: Only 0 MSI-X interrupts available for SR-IOV.
Not enough to support minimum of 2 MSI-X interrupts per VF
```

The kernel returns `ENOSPC` (-28) on the `sriov_numvfs` write. Previously the operator propagated this as a generic write error with no actionable guidance, making diagnosis difficult.

## Fix

Wrap `ENOSPC` errors from `sriov_numvfs` writes with a clear message identifying the MSI-X exhaustion root cause and pointing to the `irdma` blacklist workaround.

## Workaround (for users)

Until the upstream `ice` driver fix (`msix_vec_per_pf_max` devlink parameter, targeting Linux 6.14) is backported to RHEL:

```bash
echo "blacklist irdma" > /etc/modprobe.d/disable-irdma.conf
dracut -f
# reboot, then VF creation succeeds
```

## Test plan

- [x] Unit test added: `SetSriovNumVfs` with `/dev/full` symlink returns error containing `"insufficient MSI-X vectors"` and wraps `syscall.ENOSPC`
- [x] Existing `SetSriovNumVfs` tests still pass

Fixes: https://issues.redhat.com/browse/OCPBUGS-82499

🤖 Generated with [Claude Code](https://claude.com/claude-code)