### PR TITLE
Enable s390x architecture for the operator bundle

### DIFF
--- a/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
@@ -155,6 +155,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: sriov-network-operator.v4.22.0
   namespace: openshift-sriov-network-operator
 spec:

--- a/config/manifests/bases/sriov-network-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sriov-network-operator.clusterserviceversion.yaml
@@ -60,6 +60,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: sriov-network-operator.v0.0.0
   namespace: openshift-sriov-network-operator
 spec:

--- a/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
+++ b/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
@@ -155,6 +155,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: sriov-network-operator.v4.22.0
   namespace: openshift-sriov-network-operator
 spec:


### PR DESCRIPTION
Declare s390x (IBM Z mainframe) as a supported architecture in the ClusterServiceVersion manifests. This enables the operator to be installed and run on s390x clusters via OLM.

Changes:
- Add operatorframework.io/arch.s390x: supported annotation to CSV files
- Update bundle, config, and stable manifests Follows the same pattern as existing architecture support (amd64, arm64, ppc64le).

Following https://olm.operatorframework.io/docs/advanced-tasks/ship-operator-supporting-multiarch/ to add the s390x target architecture.

Reference PR:- https://github.com/openshift/sriov-network-operator/pull/1090