### PR TITLE
OCPBUGS-79399: [release-4.20] block device plugin until SR-IOV config applied

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ kustomize: ## Download kustomize locally if necessary.
 
 ENVTEST = $(BIN_DIR)/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.16)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.20)
 
 GOMOCK = $(shell pwd)/bin/mockgen
 gomock:

--- a/README.md
+++ b/README.md
@@ -355,6 +355,10 @@ Feature gates are used to enable or disable specific features in the operator.
   - **Description:** Enables the firmware reset via `mstfwreset` before a system reboot. This feature is specific to Mellanox network devices and is used to ensure that the firmware is properly reset during system maintenance.
   - **Default:** Disabled
 
+6. **Block Device Plugin Until Configured** (`blockDevicePluginUntilConfigured`)
+  - **Description:** Prevents the SR-IOV device plugin from starting until the sriov-config-daemon has applied the SR-IOV configuration for the node. When enabled, the device plugin daemonset runs an init container that sets a wait-for-config annotation on its pod and waits until the sriov-config-daemon removes this annotation after applying the configuration. This addresses the race condition where the device plugin starts and reports available resources before the configuration is actually applied, which can lead to pods being scheduled prematurely.
+  - **Default:** Disabled
+
 ### Enabling Feature Gates
 
 To enable a feature gate, add it to your configuration file or command line with the desired state. For example, to enable the `resourceInjectorMatchCondition` feature gate, you would specify:

--- a/bindata/manifests/plugins/002-rbac.yaml
+++ b/bindata/manifests/plugins/002-rbac.yaml
@@ -33,3 +33,27 @@ subjects:
   - kind: ServiceAccount
     name: sriov-device-plugin
     namespace: {{.Namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sriov-device-plugin-pod-access
+  namespace: {{.Namespace}}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sriov-device-plugin-pod-access
+  namespace: {{.Namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sriov-device-plugin-pod-access
+subjects:
+- kind: ServiceAccount
+  name: sriov-device-plugin
+  namespace: {{.Namespace}}

--- a/bindata/manifests/plugins/sriov-device-plugin.yaml
+++ b/bindata/manifests/plugins/sriov-device-plugin.yaml
@@ -41,8 +41,31 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .BlockDevicePluginUntilConfigured }}
+      initContainers:
+      - name: sriov-device-plugin-init
+        image: {{.SRIOVNetworkConfigDaemonImage}}
+        command:
+        - sriov-network-config-daemon
+        - wait-for-config
+        - --pod-name=$(POD_NAME)
+        - --pod-namespace=$(POD_NAMESPACE)
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      {{- end }}
       containers:
+      {{- if .BlockDevicePluginUntilConfigured }}
+      - name: sriov-device-plugin-main
+      {{- else }}
       - name: sriov-device-plugin
+      {{- end }}
         image: {{.SRIOVDevicePluginImage}}
         args:
         - --log-level=10

--- a/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
@@ -462,13 +462,11 @@ spec:
           resources:
           - pods
           verbs:
-          - '*'
-        - apiGroups:
-          - apps
-          resources:
-          - daemonsets
-          verbs:
-          - '*'
+          - get
+          - list
+          - watch
+          - delete
+          - patch
         - apiGroups:
           - sriovnetwork.openshift.io
           resources:
@@ -492,18 +490,18 @@ spec:
           - get
           - update
         - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - '*'
+        - apiGroups:
           - ""
           resources:
           - events
           verbs:
           - create
           - patch
-        - apiGroups:
-          - coordination.k8s.io
-          resources:
-          - leases
-          verbs:
-          - '*'
         serviceAccountName: sriov-network-config-daemon
       - rules:
         - apiGroups:

--- a/cmd/sriov-network-config-daemon/waitforconfig.go
+++ b/cmd/sriov-network-config-daemon/waitforconfig.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
+	snolog "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/log"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
+)
+
+var (
+	waitForConfigCmd = &cobra.Command{
+		Use:   "wait-for-config",
+		Short: "Wait for SR-IOV configuration to be applied",
+		Long: "Init container command that sets annotation on pod and waits for " +
+			"sriov-config-daemon to apply configuration and remove the annotation",
+		RunE: runWaitForConfigCmd,
+	}
+
+	waitForConfigOpts struct {
+		podName      string
+		podNamespace string
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(waitForConfigCmd)
+	waitForConfigCmd.PersistentFlags().StringVar(&waitForConfigOpts.podName, "pod-name", "",
+		"kubernetes pod name of the device plugin")
+	waitForConfigCmd.PersistentFlags().StringVar(&waitForConfigOpts.podNamespace, "pod-namespace", "",
+		"kubernetes namespace where the device plugin pod is running")
+}
+
+type WaitForConfigReconciler struct {
+	client.Client
+	Pod    types.NamespacedName
+	Cancel context.CancelFunc
+}
+
+func (r *WaitForConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// This check is currently redundant since the cache is configured to watch only the target pod object.
+	// However, it is intentionally included to document this assumption and to provide a safeguard in case
+	// the cache configuration is modified in the future to watch additional pods.
+	if r.Pod != req.NamespacedName {
+		return ctrl.Result{}, nil
+	}
+
+	pod := &corev1.Pod{}
+	if err := r.Get(ctx, req.NamespacedName, pod); err != nil {
+		logger.Error(err, "Failed to get pod")
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !utils.ObjectHasAnnotationKey(pod, consts.DevicePluginWaitConfigAnnotation) {
+		logger.Info("Annotation removed, device plugin can proceed")
+		r.Cancel()
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("Annotation still present, waiting...")
+	return ctrl.Result{RequeueAfter: consts.DaemonRequeueTime}, nil
+}
+
+func (r *WaitForConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Pod{}).
+		Complete(r)
+}
+
+func validateWaitForConfigOpts() error {
+	if waitForConfigOpts.podName == "" {
+		return fmt.Errorf("--pod-name is required")
+	}
+	if waitForConfigOpts.podNamespace == "" {
+		return fmt.Errorf("--pod-namespace is required")
+	}
+	return nil
+}
+
+func runWaitForConfigCmd(cmd *cobra.Command, args []string) error {
+	snolog.InitLog()
+	setupLog := log.Log.WithName("wait-for-config")
+
+	if err := validateWaitForConfigOpts(); err != nil {
+		setupLog.Error(err, "invalid command line arguments")
+		return err
+	}
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		setupLog.Error(err, "failed to get in-cluster config")
+		return err
+	}
+
+	return startWaitForConfigManager(setupLog, config, types.NamespacedName{Name: waitForConfigOpts.podName, Namespace: waitForConfigOpts.podNamespace})
+}
+
+func startWaitForConfigManager(setupLog logr.Logger, config *rest.Config, podName types.NamespacedName) error {
+	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
+	defer cancel()
+
+	setupLog.Info("Starting wait-for-config", "pod", podName)
+
+	// Create a temporary client to set the annotation immediately
+	tempClient, err := client.New(config, client.Options{})
+	if err != nil {
+		setupLog.Error(err, "failed to create kubernetes client")
+		return err
+	}
+
+	// Set annotation on pod to signal that we are waiting for config
+	setupLog.Info("Setting annotation on pod", "annotation", consts.DevicePluginWaitConfigAnnotation)
+	err = setAnnotationOnPod(context.Background(), setupLog, tempClient, podName)
+	if err != nil {
+		setupLog.Error(err, "failed to set annotation on pod")
+		return err
+	}
+	setupLog.Info("Annotation set successfully, waiting for removal")
+
+	// Configure Manager
+	// Watch only specific pod object
+	selector := fields.SelectorFromSet(fields.Set{"metadata.name": podName.Name})
+	mgr, err := ctrl.NewManager(config, ctrl.Options{
+		Cache: cache.Options{
+			DefaultNamespaces: map[string]cache.Config{podName.Namespace: {}},
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Pod{}: {Field: selector},
+			},
+		},
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		return err
+	}
+
+	if err = (&WaitForConfigReconciler{
+		Client: mgr.GetClient(),
+		Pod:    podName,
+		Cancel: cancel,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller")
+		return err
+	}
+
+	setupLog.Info("Starting manager")
+	if err := mgr.Start(ctx); err != nil {
+		setupLog.Error(err, "problem running manager")
+		return err
+	}
+	return nil
+}
+
+// setAnnotationOnPod sets the wait-for-config annotation on the pod
+func setAnnotationOnPod(ctx context.Context, logger logr.Logger, c client.Client, podName types.NamespacedName) error {
+	return wait.ExponentialBackoff(wait.Backoff{
+		Steps:    10,
+		Duration: 1 * time.Second,
+		Factor:   2.0,
+		Jitter:   0.1,
+		Cap:      30 * time.Second,
+	}, func() (bool, error) {
+		pod := &corev1.Pod{}
+		if err := c.Get(ctx, podName, pod); err != nil {
+			logger.Error(err, "failed to get pod, retrying")
+			return false, nil
+		}
+		if err := utils.AnnotateObject(ctx, pod, consts.DevicePluginWaitConfigAnnotation, "true", c); err != nil {
+			logger.Error(err, "failed to annotate pod, retrying")
+			return false, nil
+		}
+		return true, nil
+	})
+}

--- a/cmd/sriov-network-config-daemon/waitforconfig_test.go
+++ b/cmd/sriov-network-config-daemon/waitforconfig_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"context"
+	"os"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util"
+)
+
+var _ = Describe("WaitForConfig", func() {
+	Context("validateWaitForConfigOpts", func() {
+		BeforeEach(func() {
+			waitForConfigOpts.podName = ""
+			waitForConfigOpts.podNamespace = ""
+		})
+		It("should return error when pod-name is not provided", func() {
+			waitForConfigOpts.podNamespace = "test-namespace"
+			err := validateWaitForConfigOpts()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("--pod-name is required"))
+		})
+		It("should return error when pod-namespace is not provided", func() {
+			waitForConfigOpts.podName = "test-pod"
+			err := validateWaitForConfigOpts()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("--pod-namespace is required"))
+		})
+		It("should return nil when both options are provided", func() {
+			waitForConfigOpts.podName = "test-pod"
+			waitForConfigOpts.podNamespace = "test-namespace"
+			err := validateWaitForConfigOpts()
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+	Context("startWaitForConfigManager", Ordered, func() {
+		const testNamespace = "test-namespace"
+		var (
+			testEnv   *envtest.Environment
+			cfg       *rest.Config
+			k8sClient client.Client
+		)
+		BeforeAll(func() {
+			By("changing to project root directory")
+			err := os.Chdir("../..")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("bootstrapping test environment")
+			testEnv = &envtest.Environment{}
+
+			cfg, err = testEnv.Start()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg).NotTo(BeNil())
+
+			By("creating K8s client")
+			k8sClient, err = client.New(cfg, client.Options{Scheme: k8sscheme.Scheme})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating test namespace")
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}
+			Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
+		})
+		AfterAll(func() {
+			By("tearing down the test environment")
+			if testEnv != nil {
+				Eventually(func() error {
+					return testEnv.Stop()
+				}, util.APITimeout, time.Second).ShouldNot(HaveOccurred())
+			}
+		})
+		It("should set annotation and exit when annotation is removed", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-pod-",
+					Namespace:    testNamespace,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test", Image: "test"}},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), pod)).To(Succeed())
+			podName := client.ObjectKeyFromObject(pod)
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(context.Background(), pod)
+			})
+
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			var managerErr error
+			go func() {
+				defer wg.Done()
+				defer GinkgoRecover()
+				managerErr = startWaitForConfigManager(
+					GinkgoLogr.WithName("wait-for-config"), cfg, podName)
+			}()
+
+			By("waiting for annotation to be set")
+			Eventually(func(g Gomega) {
+				p := &corev1.Pod{}
+				g.Expect(k8sClient.Get(context.Background(), podName, p)).To(Succeed())
+				g.Expect(p.Annotations).To(HaveKeyWithValue(
+					consts.DevicePluginWaitConfigAnnotation, "true"))
+			}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
+
+			By("removing annotation to signal config is applied")
+			p := &corev1.Pod{}
+			Expect(k8sClient.Get(context.Background(), podName, p)).To(Succeed())
+			originalPod := p.DeepCopy()
+			delete(p.Annotations, consts.DevicePluginWaitConfigAnnotation)
+			Expect(k8sClient.Patch(context.Background(), p, client.MergeFrom(originalPod))).To(Succeed())
+
+			By("waiting for manager to exit")
+			done := make(chan struct{})
+			go func() {
+				wg.Wait()
+				close(done)
+			}()
+			Eventually(done, 30*time.Second).Should(BeClosed())
+			Expect(managerErr).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/config/rbac/sriov-network-config-daemon_role.yaml
+++ b/config/rbac/sriov-network-config-daemon_role.yaml
@@ -8,13 +8,11 @@ rules:
   resources:
   - pods
   verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  verbs:
-  - '*'
+    - "get"
+    - "list"
+    - "watch"
+    - "delete"
+    - "patch"
 - apiGroups:
   - sriovnetwork.openshift.io
   resources:
@@ -38,15 +36,15 @@ rules:
   - get
   - update
 - apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
   - 'coordination.k8s.io'
   resources:
   - 'leases'
   verbs:
   - '*'
+- apiGroups:
+    - ""
+  resources:
+    - events
+  verbs:
+    - create
+    - patch

--- a/controllers/helper.go
+++ b/controllers/helper.go
@@ -180,11 +180,13 @@ func syncPluginDaemonObjs(ctx context.Context,
 	data := render.MakeRenderData()
 	data.Data["Namespace"] = vars.Namespace
 	data.Data["SRIOVDevicePluginImage"] = os.Getenv("SRIOV_DEVICE_PLUGIN_IMAGE")
+	data.Data["SRIOVNetworkConfigDaemonImage"] = os.Getenv("SRIOV_NETWORK_CONFIG_DAEMON_IMAGE")
 	data.Data["ReleaseVersion"] = os.Getenv("RELEASEVERSION")
 	data.Data["ResourcePrefix"] = vars.ResourcePrefix
 	data.Data["ImagePullSecrets"] = GetImagePullSecrets()
 	data.Data["NodeSelectorField"] = GetNodeSelectorForDevicePlugin(dc)
 	data.Data["UseCDI"] = dc.Spec.UseCDI
+	data.Data["BlockDevicePluginUntilConfigured"] = dc.Spec.FeatureGates[constants.BlockDevicePluginUntilConfiguredFeatureGate]
 	objs, err := renderDsForCR(constants.PluginPath, &data)
 	if err != nil {
 		logger.Error(err, "Fail to render SR-IoV manifests")

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -88,6 +88,7 @@ rules:
     - "list"
     - "watch"
     - "delete"
+    - "patch"
 - apiGroups:
   - sriovnetwork.openshift.io
   resources:

--- a/deployment/sriov-network-operator-chart/templates/role.yaml
+++ b/deployment/sriov-network-operator-chart/templates/role.yaml
@@ -95,6 +95,7 @@ rules:
       - "list"
       - "watch"
       - "delete"
+      - "patch"
   - apiGroups:
       - sriovnetwork.openshift.io
     resources:

--- a/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
+++ b/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
@@ -462,13 +462,11 @@ spec:
           resources:
           - pods
           verbs:
-          - '*'
-        - apiGroups:
-          - apps
-          resources:
-          - daemonsets
-          verbs:
-          - '*'
+          - get
+          - list
+          - watch
+          - delete
+          - patch
         - apiGroups:
           - sriovnetwork.openshift.io
           resources:
@@ -492,18 +490,18 @@ spec:
           - get
           - update
         - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - '*'
+        - apiGroups:
           - ""
           resources:
           - events
           verbs:
           - create
           - patch
-        - apiGroups:
-          - coordination.k8s.io
-          resources:
-          - leases
-          verbs:
-          - '*'
         serviceAccountName: sriov-network-config-daemon
       - rules:
         - apiGroups:

--- a/pkg/consts/constants.go
+++ b/pkg/consts/constants.go
@@ -99,6 +99,8 @@ const (
 
 	OwnerRefAnnotation = "sriovnetwork.openshift.io/owner-ref"
 
+	DevicePluginWaitConfigAnnotation = "sriovnetwork.openshift.io/device-plugin-wait-config"
+
 	// NodeStateKeepUntilAnnotation contains name of the "keep until time" annotation for SriovNetworkNodeState object.
 	// The "keep until time" specifies the earliest time at which the state object can be removed
 	// if the daemon's pod is not found on the node.
@@ -171,6 +173,9 @@ const (
 
 	// ManageSoftwareBridgesFeatureGate: enables management of software bridges by the operator
 	ManageSoftwareBridgesFeatureGate = "manageSoftwareBridges"
+
+	// BlockDevicePluginUntilConfiguredFeatureGate: blocks the device plugin until the configuration is applied
+	BlockDevicePluginUntilConfiguredFeatureGate = "blockDevicePluginUntilConfigured"
 
 	// MellanoxFirmwareResetFeatureGate: enables the firmware reset via mstfwreset before a reboot
 	MellanoxFirmwareResetFeatureGate = "mellanoxFirmwareReset"

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -367,6 +367,20 @@ func (dn *NodeReconciler) checkSystemdStatus() (*hosttypes.SriovResult, bool, er
 // 7. Updating the lastAppliedGeneration to the current generation.
 func (dn *NodeReconciler) apply(ctx context.Context, desiredNodeState *sriovnetworkv1.SriovNetworkNodeState, reqReboot bool, sriovResult *hosttypes.SriovResult) (ctrl.Result, error) {
 	reqLogger := log.FromContext(ctx).WithName("Apply")
+
+	// Restart the device plugin *before* applying configuration if the
+	// BlockDevicePluginUntilConfiguredFeatureGate feature is enabled.
+	// With this gate enabled, the device plugin will remain blocked until it is
+	// explicitly unblocked after configuration (see waitForDevicePluginPodAndTryUnblock).
+	// If the feature gate is not enabled, preserve legacy behavior by
+	// restarting the device plugin *after* configuration is applied.
+	if vars.FeatureGate.IsEnabled(consts.BlockDevicePluginUntilConfiguredFeatureGate) {
+		if err := dn.restartDevicePluginPod(ctx); err != nil {
+			reqLogger.Error(err, "failed to restart device plugin on the node")
+			return ctrl.Result{}, err
+		}
+	}
+
 	// apply the vendor plugins after we are done with drain if needed
 	for k, p := range dn.loadedPlugins {
 		// Skip both the general and virtual plugin apply them last
@@ -468,7 +482,7 @@ func (dn *NodeReconciler) tryUnblockDevicePlugin(ctx context.Context,
 	for _, pod := range devicePluginPods {
 		if err := utils.RemoveAnnotationFromObject(ctx, &pod,
 			consts.DevicePluginWaitConfigAnnotation, dn.client); err != nil {
-			return fmt.Errorf("failed to remove wait-for-config annotation from pod: %w", err)
+			return fmt.Errorf("failed to remove %s annotation from pod: %w", consts.DevicePluginWaitConfigAnnotation, err)
 		}
 	}
 	return nil
@@ -653,18 +667,18 @@ func (dn *NodeReconciler) restartDevicePluginPod(ctx context.Context) error {
 // for the periodic check. We expect to have at least one device plugin pod for the node.
 func (dn *NodeReconciler) waitForDevicePluginPodAndTryUnblock(ctx context.Context, desiredNodeState *sriovnetworkv1.SriovNetworkNodeState) error {
 	funcLog := log.Log.WithName("waitForDevicePluginPodAndTryUnblock")
-	funcLog.Info("waiting for device plugin to set wait-for-config annotation")
+	funcLog.Info("waiting for device plugin to set wait-for-config annotation", "annotation", consts.DevicePluginWaitConfigAnnotation)
 	var devicePluginPods []corev1.Pod
 	err := wait.PollUntilContextTimeout(ctx, time.Second, 2*time.Minute, true,
 		func(ctx context.Context) (bool, error) {
 			var err error
 			devicePluginPods, err = dn.getDevicePluginPodsForNode(ctx)
 			if err != nil {
-				log.Log.Error(err, "waitForDevicePluginPodAndUnblock(): failed to get device plugin pod while waiting for a new pod to start")
+				funcLog.Error(err, "failed to get device plugin pod while waiting for a new pod to start")
 				return false, err
 			}
 			if len(devicePluginPods) == 0 {
-				log.Log.V(2).Info("waitForDevicePluginPodAndUnblock(): no device plugin pods found while waiting for a new pod to start")
+				funcLog.V(2).Info("no device plugin pods found while waiting for a new pod to start")
 				return false, nil
 			}
 			for _, pod := range devicePluginPods {
@@ -673,12 +687,12 @@ func (dn *NodeReconciler) waitForDevicePluginPodAndTryUnblock(ctx context.Contex
 				// may also match our selector. Since unmanaged pods won't have this annotation,
 				// we only require one pod (the managed one) to have it.
 				if utils.ObjectHasAnnotationKey(&pod, consts.DevicePluginWaitConfigAnnotation) {
-					log.Log.Info("waitForDevicePluginPodAndUnblock(): wait-for-config annotation found on pod",
+					funcLog.Info("wait-for-config annotation found on pod",
 						"pod", pod.Name)
 					return true, nil
 				}
 			}
-			log.Log.V(2).Info("waitForDevicePluginPodAndUnblock(): waiting for new device plugin pod to have wait-for-config annotation")
+			funcLog.V(2).Info("waiting for new device plugin pod to have wait-for-config annotation")
 			return false, nil
 		})
 	if err != nil {
@@ -687,8 +701,8 @@ func (dn *NodeReconciler) waitForDevicePluginPodAndTryUnblock(ctx context.Contex
 		}
 		// If annotation is not found within the timeout, log a warning and proceed.
 		// The device plugin pod will be unblocked by the periodic check logic in tryUnblockDevicePlugin.
-		log.Log.Info("waitForDevicePluginPodAndUnblock(): WARNING: device plugin pod with " +
-			"wait-for-config annotation not found within timeout")
+		funcLog.Info("WARNING: device plugin pod with wait-for-config annotation not found within timeout")
+		return nil
 	}
 	if len(devicePluginPods) > 0 {
 		// try to unblock all device plugin pods we retrieved with the latest loop iteration

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -221,7 +221,8 @@ func (dn *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			}
 			// periodically ensure device plugin is unblocked,
 			// this is required to ensure that device plugin can start in case if it is restarted for some reason
-			if vars.FeatureGate.IsEnabled(consts.BlockDevicePluginUntilConfiguredFeatureGate) {
+			if vars.FeatureGate.IsEnabled(consts.BlockDevicePluginUntilConfiguredFeatureGate) &&
+				len(desiredNodeState.Spec.Interfaces) > 0 {
 				devicePluginPods, err := dn.getDevicePluginPodsForNode(ctx)
 				if err != nil {
 					reqLogger.Error(err, "failed to get device plugin pods")
@@ -430,9 +431,13 @@ func (dn *NodeReconciler) apply(ctx context.Context, desiredNodeState *sriovnetw
 		return ctrl.Result{}, err
 	}
 	if vars.FeatureGate.IsEnabled(consts.BlockDevicePluginUntilConfiguredFeatureGate) {
-		if err := dn.waitForDevicePluginPodAndTryUnblock(ctx, desiredNodeState); err != nil {
-			reqLogger.Error(err, "failed to wait for device plugin pod to start and try to unblock it")
-			return ctrl.Result{}, err
+		if len(desiredNodeState.Spec.Interfaces) == 0 {
+			reqLogger.Info("no interfaces in desired state, skipping device plugin wait as device plugin won't be deployed")
+		} else {
+			if err := dn.waitForDevicePluginPodAndTryUnblock(ctx, desiredNodeState); err != nil {
+				reqLogger.Error(err, "failed to wait for device plugin pod to start and try to unblock it")
+				return ctrl.Result{}, err
+			}
 		}
 	}
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	stdErrors "errors"
 	"fmt"
 	"time"
 
@@ -218,6 +219,19 @@ func (dn *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 					return ctrl.Result{}, err
 				}
 			}
+			// periodically ensure device plugin is unblocked,
+			// this is required to ensure that device plugin can start in case if it is restarted for some reason
+			if vars.FeatureGate.IsEnabled(consts.BlockDevicePluginUntilConfiguredFeatureGate) {
+				devicePluginPods, err := dn.getDevicePluginPodsForNode(ctx)
+				if err != nil {
+					reqLogger.Error(err, "failed to get device plugin pods")
+					return ctrl.Result{}, err
+				}
+				if err := dn.tryUnblockDevicePlugin(ctx, desiredNodeState, devicePluginPods); err != nil {
+					reqLogger.Error(err, "failed to unblock device plugin")
+					return ctrl.Result{}, err
+				}
+			}
 
 			return ctrl.Result{RequeueAfter: consts.DaemonRequeueTime}, nil
 		}
@@ -401,6 +415,12 @@ func (dn *NodeReconciler) apply(ctx context.Context, desiredNodeState *sriovnetw
 		reqLogger.Error(err, "failed to restart device plugin on the node")
 		return ctrl.Result{}, err
 	}
+	if vars.FeatureGate.IsEnabled(consts.BlockDevicePluginUntilConfiguredFeatureGate) {
+		if err := dn.waitForDevicePluginPodAndTryUnblock(ctx, desiredNodeState); err != nil {
+			reqLogger.Error(err, "failed to wait for device plugin pod to start and try to unblock it")
+			return ctrl.Result{}, err
+		}
+	}
 
 	err := dn.annotate(ctx, desiredNodeState, consts.DrainIdle)
 	if err != nil {
@@ -431,14 +451,33 @@ func (dn *NodeReconciler) apply(ctx context.Context, desiredNodeState *sriovnetw
 
 	// update the lastAppliedGeneration
 	dn.lastAppliedGeneration = desiredNodeState.Generation
+
 	return ctrl.Result{RequeueAfter: consts.DaemonRequeueTime}, nil
+}
+
+// tryUnblockDevicePlugin checks if the device plugin can be unblocked
+func (dn *NodeReconciler) tryUnblockDevicePlugin(ctx context.Context,
+	desiredNodeState *sriovnetworkv1.SriovNetworkNodeState, devicePluginPods []corev1.Pod) error {
+	funcLog := log.Log.WithName("tryUnblockDevicePlugin")
+	funcLog.Info("check if we need to remove the wait-for-config annotation")
+	// we want to unblock the device plugin only if the desired state contains configuration for the interfaces
+	if len(desiredNodeState.Spec.Interfaces) == 0 {
+		funcLog.Info("desired node state has no interfaces, keep the wait-for-config annotation")
+		return nil
+	}
+	for _, pod := range devicePluginPods {
+		if err := utils.RemoveAnnotationFromObject(ctx, &pod,
+			consts.DevicePluginWaitConfigAnnotation, dn.client); err != nil {
+			return fmt.Errorf("failed to remove wait-for-config annotation from pod: %w", err)
+		}
+	}
+	return nil
 }
 
 // checkHostStateDrift returns true if the node state drifted from the nodeState policy
 // Check if there is a change in the host network interfaces that require a reconfiguration by the daemon
 func (dn *NodeReconciler) checkHostStateDrift(ctx context.Context, desiredNodeState *sriovnetworkv1.SriovNetworkNodeState) (bool, error) {
 	funcLog := log.Log.WithName("checkHostStateDrift()")
-
 	// Skip when SriovNetworkNodeState object has just been created.
 	if desiredNodeState.GetGeneration() == 1 && len(desiredNodeState.Spec.Interfaces) == 0 {
 		err := dn.HostHelpers.ClearPCIAddressFolder()
@@ -540,64 +579,123 @@ func (dn *NodeReconciler) handleDrain(ctx context.Context, desiredNodeState *sri
 	return true, dn.annotate(ctx, desiredNodeState, annotation)
 }
 
+// getDevicePluginPods returns the device plugin pods running on this node
+func (dn *NodeReconciler) getDevicePluginPodsForNode(ctx context.Context) ([]corev1.Pod, error) {
+	pods := &corev1.PodList{}
+	err := dn.client.List(ctx, pods, &client.ListOptions{
+		Namespace: vars.Namespace, Raw: &metav1.ListOptions{
+			LabelSelector: "app=sriov-device-plugin",
+			FieldSelector: "spec.nodeName=" + vars.NodeName,
+		}})
+	if err != nil {
+		log.Log.Error(err, "getDevicePluginPodsForNode(): failed to list device plugin pods")
+		return []corev1.Pod{}, err
+	}
+	if len(pods.Items) == 0 {
+		log.Log.Info("getDevicePluginPodsForNode(): no device plugin pods found")
+		return []corev1.Pod{}, nil
+	}
+	return pods.Items, nil
+}
+
 // restartDevicePluginPod restarts the device plugin pod on the specified node.
 //
 // The function checks if the pod exists, deletes it if found, and waits for it to be deleted successfully.
 func (dn *NodeReconciler) restartDevicePluginPod(ctx context.Context) error {
-	log.Log.V(2).Info("restartDevicePluginPod(): try to restart device plugin pod")
-	pods := &corev1.PodList{}
-	err := dn.client.List(ctx, pods, &client.ListOptions{
-		Namespace: vars.Namespace, Raw: &metav1.ListOptions{
-			LabelSelector:   "app=sriov-device-plugin",
-			FieldSelector:   "spec.nodeName=" + vars.NodeName,
-			ResourceVersion: "0",
-		}})
+	funcLog := log.Log.WithName("restartDevicePluginPod")
+	funcLog.V(2).Info("try to restart device plugin pod")
+	devicePluginPods, err := dn.getDevicePluginPodsForNode(ctx)
 	if err != nil {
-		if errors.IsNotFound(err) {
-			log.Log.Info("restartDevicePluginPod(): device plugin pod exited")
-			return nil
-		}
-		log.Log.Error(err, "restartDevicePluginPod(): Failed to list device plugin pod, retrying")
 		return err
 	}
-
-	if len(pods.Items) == 0 {
-		log.Log.Info("restartDevicePluginPod(): device plugin pod exited")
-		return nil
-	}
-
-	for _, pod := range pods.Items {
-		log.Log.V(2).Info("restartDevicePluginPod(): Found device plugin pod, deleting it", "pod-name", pod.Name)
+	for _, pod := range devicePluginPods {
+		podUID := pod.UID
+		funcLog.V(2).Info("Found device plugin pod, deleting it",
+			"pod-name", pod.Name, "pod-uid", podUID)
 		err = dn.client.Delete(ctx, &pod)
 		if errors.IsNotFound(err) {
-			log.Log.Info("restartDevicePluginPod(): pod to delete not found")
+			funcLog.Info("pod to delete not found")
 			continue
 		}
 		if err != nil {
-			log.Log.Error(err, "restartDevicePluginPod(): Failed to delete device plugin pod, retrying")
+			funcLog.Error(err, "Failed to delete device plugin pod")
 			return err
 		}
-
-		tmpPod := &corev1.Pod{}
-		if err := wait.PollUntilContextCancel(ctx, 3*time.Second, true, func(ctx context.Context) (bool, error) {
-			err := dn.client.Get(ctx, client.ObjectKeyFromObject(&pod), tmpPod)
+		newPod := &corev1.Pod{}
+		if err := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
+			err := dn.client.Get(ctx, client.ObjectKeyFromObject(&pod), newPod)
 			if errors.IsNotFound(err) {
-				log.Log.Info("restartDevicePluginPod(): device plugin pod exited")
+				funcLog.Info("device plugin pod exited")
 				return true, nil
 			}
-
 			if err != nil {
-				log.Log.Error(err, "restartDevicePluginPod(): Failed to check for device plugin exit, retrying")
-			} else {
-				log.Log.Info("restartDevicePluginPod(): waiting for device plugin pod to exit", "pod-name", pod.Name)
+				return false, fmt.Errorf("failed to get device plugin pod: %w", err)
 			}
+			// Check if the pod was recreated (different UID means it's a new pod)
+			if newPod.UID != podUID {
+				funcLog.Info("device plugin pod was recreated",
+					"old-uid", podUID, "new-uid", newPod.UID)
+				return true, nil
+			}
+			funcLog.Info("waiting for device plugin pod to exit",
+				"pod-name", pod.Name, "pod-uid", newPod.UID)
 			return false, nil
 		}); err != nil {
-			log.Log.Error(err, "restartDevicePluginPod(): failed to wait for checking pod deletion")
+			funcLog.Error(err, "failed to wait device plugin pod to exit")
 			return err
 		}
 	}
+	return nil
+}
 
+// waitForDevicePluginPodAndTryUnblock waits for the new device plugin pod to start and set the wait-for-config annotation. This allows us to unblock
+// the new device plugin instance within the same reconciliation loop without needing to wait
+// for the periodic check. We expect to have at least one device plugin pod for the node.
+func (dn *NodeReconciler) waitForDevicePluginPodAndTryUnblock(ctx context.Context, desiredNodeState *sriovnetworkv1.SriovNetworkNodeState) error {
+	funcLog := log.Log.WithName("waitForDevicePluginPodAndTryUnblock")
+	funcLog.Info("waiting for device plugin to set wait-for-config annotation")
+	var devicePluginPods []corev1.Pod
+	err := wait.PollUntilContextTimeout(ctx, time.Second, 2*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			var err error
+			devicePluginPods, err = dn.getDevicePluginPodsForNode(ctx)
+			if err != nil {
+				log.Log.Error(err, "waitForDevicePluginPodAndUnblock(): failed to get device plugin pod while waiting for a new pod to start")
+				return false, err
+			}
+			if len(devicePluginPods) == 0 {
+				log.Log.V(2).Info("waitForDevicePluginPodAndUnblock(): no device plugin pods found while waiting for a new pod to start")
+				return false, nil
+			}
+			for _, pod := range devicePluginPods {
+				// Wait for at least one device plugin pod to have the wait-for-config annotation.
+				// Usually there's only one device plugin pod per node, but unmanaged (by the operator) pods
+				// may also match our selector. Since unmanaged pods won't have this annotation,
+				// we only require one pod (the managed one) to have it.
+				if utils.ObjectHasAnnotationKey(&pod, consts.DevicePluginWaitConfigAnnotation) {
+					log.Log.Info("waitForDevicePluginPodAndUnblock(): wait-for-config annotation found on pod",
+						"pod", pod.Name)
+					return true, nil
+				}
+			}
+			log.Log.V(2).Info("waitForDevicePluginPodAndUnblock(): waiting for new device plugin pod to have wait-for-config annotation")
+			return false, nil
+		})
+	if err != nil {
+		if !stdErrors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		// If annotation is not found within the timeout, log a warning and proceed.
+		// The device plugin pod will be unblocked by the periodic check logic in tryUnblockDevicePlugin.
+		log.Log.Info("waitForDevicePluginPodAndUnblock(): WARNING: device plugin pod with " +
+			"wait-for-config annotation not found within timeout")
+	}
+	if len(devicePluginPods) > 0 {
+		// try to unblock all device plugin pods we retrieved with the latest loop iteration
+		if err := dn.tryUnblockDevicePlugin(ctx, desiredNodeState, devicePluginPods); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -334,6 +335,97 @@ var _ = Describe("Daemon Controller", Ordered, func() {
 			eventuallySyncStatusEqual(nodeState, constants.SyncStatusSucceeded)
 			assertLastStatusTransitionsContains(nodeState, 2, constants.SyncStatusInProgress)
 		})
+
+		It("Should unblock the device plugin pod when configuration is finished", func(ctx context.Context) {
+			DeferCleanup(func(x bool) { vars.DisableDrain = x }, vars.DisableDrain)
+			vars.DisableDrain = true
+			DeferCleanup(func(m map[string]bool) { vars.FeatureGate.Init(m) }, map[string]bool{})
+			vars.FeatureGate.Init(map[string]bool{constants.BlockDevicePluginUntilConfiguredFeatureGate: true})
+
+			devicePluginPodName := client.ObjectKey{
+				Name:      "sriov-device-plugin-test",
+				Namespace: testNamespace,
+			}
+			devicePluginPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      devicePluginPodName.Name,
+					Namespace: devicePluginPodName.Namespace,
+					Labels: map[string]string{
+						"app": "sriov-device-plugin",
+					},
+					Annotations: map[string]string{
+						constants.DevicePluginWaitConfigAnnotation: "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "node1",
+					Containers: []corev1.Container{
+						{
+							Name:  "device-plugin",
+							Image: "test-image",
+						},
+					},
+				},
+			}
+			pr := newPodRecreator(k8sClient, devicePluginPod, 100*time.Millisecond)
+			pr.Start(ctx)
+			DeferCleanup(pr.Stop)
+
+			discoverSriovReturn.Store(&[]sriovnetworkv1.InterfaceExt{
+				{
+					Name:           "eno1",
+					Driver:         "ice",
+					PciAddress:     "0000:16:00.0",
+					DeviceID:       "1593",
+					Vendor:         "8086",
+					EswitchMode:    "legacy",
+					LinkAdminState: "up",
+					LinkSpeed:      "10000 Mb/s",
+					LinkType:       "ETH",
+					Mac:            "aa:bb:cc:dd:ee:ff",
+					Mtu:            1500,
+					TotalVfs:       1,
+					NumVfs:         1,
+					VFs: []sriovnetworkv1.VirtualFunction{
+						{
+							Name:       "eno1f0",
+							PciAddress: "0000:16:00.1",
+							VfID:       0,
+							Driver:     "iavf",
+						},
+					},
+				},
+			})
+			EventuallyWithOffset(1, func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: nodeState.Namespace, Name: nodeState.Name}, nodeState)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				nodeState.Spec.Interfaces = []sriovnetworkv1.Interface{
+					{Name: "eno1",
+						PciAddress: "0000:16:00.0",
+						LinkType:   "eth",
+						NumVfs:     12,
+						VfGroups: []sriovnetworkv1.VfGroup{
+							{ResourceName: "test",
+								DeviceType: "netdevice",
+								PolicyName: "test-policy",
+								VfRange:    "eno1#0-0"},
+						}},
+				}
+				err = k8sClient.Update(ctx, nodeState)
+				g.Expect(err).ToNot(HaveOccurred())
+			}, waitTime, retryTime).Should(Succeed())
+
+			eventuallySyncStatusEqual(nodeState, constants.SyncStatusSucceeded)
+			assertLastStatusTransitionsContains(nodeState, 2, constants.SyncStatusInProgress)
+
+			// Verify that the device plugin pod is present and the 'wait-for-config' annotation has been removed upon completion of configuration
+			Eventually(func(g Gomega) {
+				devicePluginPod := &corev1.Pod{}
+				g.Expect(k8sClient.Get(ctx, devicePluginPodName, devicePluginPod)).ToNot(HaveOccurred())
+				g.Expect(devicePluginPod.Annotations).ToNot(HaveKey(constants.DevicePluginWaitConfigAnnotation))
+			}, waitTime, retryTime).Should(Succeed())
+		})
 	})
 })
 
@@ -427,4 +519,76 @@ func assertLastStatusTransitionsContains(nodeState *sriovnetworkv1.SriovNetworkN
 	// `Status changed from: Succeed to: InProgress`
 	Expect(events.Items).To(ContainElement(
 		HaveField("Message", ContainSubstring("to: "+status))))
+}
+
+// podRecreator manages a pod lifecycle in the background, ensuring the pod
+// is recreated if it gets deleted until explicitly stopped.
+type podRecreator struct {
+	client       client.Client
+	podSpec      *corev1.Pod
+	pollInterval time.Duration
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// newPodRecreator creates a new podRecreator instance.
+// podSpec must have Name and Namespace set.
+func newPodRecreator(c client.Client, podSpec *corev1.Pod, pollInterval time.Duration) *podRecreator {
+	return &podRecreator{
+		client:       c,
+		podSpec:      podSpec,
+		pollInterval: pollInterval,
+	}
+}
+
+// Start begins the background loop that ensures the pod exists.
+// It creates the pod if it doesn't exist and periodically checks
+// if the pod was removed, recreating it if necessary.
+func (pr *podRecreator) Start(ctx context.Context) {
+	ctx, pr.cancel = context.WithCancel(ctx)
+	pr.ensurePodExists(ctx)
+	pr.wg.Add(1)
+	go func() {
+		defer pr.wg.Done()
+		pr.ensurePodExists(ctx)
+		ticker := time.NewTicker(pr.pollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				pr.ensurePodExists(ctx)
+			}
+		}
+	}()
+}
+
+// Stop stops the background loop and waits for it to finish.
+func (pr *podRecreator) Stop() {
+	if pr.cancel != nil {
+		pr.cancel()
+	}
+	pr.wg.Wait()
+	pr.client.Delete(context.Background(), pr.podSpec)
+}
+
+// ensurePodExists checks if the pod exists and creates it if not found.
+func (pr *podRecreator) ensurePodExists(ctx context.Context) {
+	pod := &corev1.Pod{}
+	err := pr.client.Get(ctx, types.NamespacedName{
+		Name:      pr.podSpec.Name,
+		Namespace: pr.podSpec.Namespace,
+	}, pod)
+	if apiErrors.IsNotFound(err) {
+		// Pod not found, create it
+		newPod := pr.podSpec.DeepCopy()
+		_ = pr.client.Create(ctx, newPod)
+		return
+	}
+	if err == nil && pod.DeletionTimestamp != nil {
+		// the pod has nodeName set, we need to force delete it to simulate kubelet behavior
+		_ = pr.client.Delete(ctx, pod, client.GracePeriodSeconds(0))
+	}
 }

--- a/pkg/utils/cluster.go
+++ b/pkg/utils/cluster.go
@@ -140,3 +140,29 @@ func RemoveLabelFromNode(ctx context.Context, nodeName string, key string, c cli
 
 	return removeLabelObject(ctx, node, key, c)
 }
+
+// RemoveAnnotationFromObject removes an annotation from a kubernetes object
+func RemoveAnnotationFromObject(ctx context.Context, obj client.Object, key string, c client.Client) error {
+	newObj := obj.DeepCopyObject().(client.Object)
+	if newObj.GetAnnotations() == nil {
+		return nil
+	}
+
+	_, exist := newObj.GetAnnotations()[key]
+	if exist {
+		log.Log.V(2).Info("RemoveAnnotationFromObject(): remove annotation from object",
+			"objectName", obj.GetName(),
+			"objectKind", obj.GetObjectKind(),
+			"annotationKey", key)
+		delete(newObj.GetAnnotations(), key)
+		patch := client.MergeFrom(obj)
+		err := c.Patch(ctx,
+			newObj, patch)
+		if err != nil {
+			log.Log.Error(err, "RemoveAnnotationFromObject(): Failed to patch object")
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/utils/cluster_test.go
+++ b/pkg/utils/cluster_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package utils
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+var _ = Describe("Cluster Utils", func() {
+	Context("ObjectHasAnnotationKey", func() {
+		DescribeTable("should check if annotation key exists",
+			func(annotations map[string]string, key string, expected bool) {
+				obj := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: annotations}}
+				Expect(ObjectHasAnnotationKey(obj, key)).To(Equal(expected))
+			},
+			Entry("key exists", map[string]string{"test-key": "test-value"}, "test-key", true),
+			Entry("key does not exist", map[string]string{"other-key": "test-value"}, "test-key", false),
+			Entry("annotations is nil", nil, "test-key", false),
+		)
+	})
+	Context("ObjectHasAnnotation", func() {
+		DescribeTable("should check if annotation key and value match",
+			func(annotations map[string]string, key, value string, expected bool) {
+				obj := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: annotations}}
+				Expect(ObjectHasAnnotation(obj, key, value)).To(Equal(expected))
+			},
+			Entry("key and value match", map[string]string{"test-key": "test-value"}, "test-key", "test-value", true),
+			Entry("value does not match", map[string]string{"test-key": "other-value"}, "test-key", "test-value", false),
+			Entry("key does not exist", map[string]string{}, "test-key", "test-value", false),
+		)
+	})
+	Context("RemoveAnnotationFromObject", func() {
+		var (
+			fakeClient client.Client
+			ctx        context.Context
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+		It("should remove annotation from object", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						"to-remove":   "value",
+						"to-preserve": "value",
+					},
+				},
+			}
+			fakeClient = fake.NewClientBuilder().WithObjects(pod).Build()
+
+			err := RemoveAnnotationFromObject(ctx, pod, "to-remove", fakeClient)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify annotation was removed
+			updatedPod := &corev1.Pod{}
+			err = fakeClient.Get(ctx,
+				types.NamespacedName{Name: "test-pod", Namespace: "test-namespace"}, updatedPod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedPod.Annotations).ToNot(HaveKey("to-remove"))
+			Expect(updatedPod.Annotations).To(HaveKeyWithValue("to-preserve", "value"))
+		})
+		It("should handle nil annotations gracefully", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+				},
+			}
+			fakeClient = fake.NewClientBuilder().WithObjects(pod).Build()
+
+			err := RemoveAnnotationFromObject(ctx, pod, "any-key", fakeClient)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+	Context("AnnotateObject", func() {
+		var (
+			fakeClient client.Client
+			ctx        context.Context
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+		It("should add annotation to object without annotations", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+				},
+			}
+			fakeClient = fake.NewClientBuilder().WithObjects(pod).Build()
+
+			err := AnnotateObject(ctx, pod, "new-key", "new-value", fakeClient)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify annotation was added
+			updatedPod := &corev1.Pod{}
+			err = fakeClient.Get(ctx,
+				types.NamespacedName{Name: "test-pod", Namespace: "test-namespace"}, updatedPod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedPod.Annotations).To(HaveKeyWithValue("new-key", "new-value"))
+		})
+		It("should add annotation preserving existing annotations", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						"existing-key": "existing-value",
+					},
+				},
+			}
+			fakeClient = fake.NewClientBuilder().WithObjects(pod).Build()
+
+			err := AnnotateObject(ctx, pod, "new-key", "new-value", fakeClient)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify both annotations exist
+			updatedPod := &corev1.Pod{}
+			err = fakeClient.Get(ctx,
+				types.NamespacedName{Name: "test-pod", Namespace: "test-namespace"}, updatedPod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedPod.Annotations).To(HaveKeyWithValue("existing-key", "existing-value"))
+			Expect(updatedPod.Annotations).To(HaveKeyWithValue("new-key", "new-value"))
+		})
+		It("should not patch if annotation already has same value", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						"same-key": "same-value",
+					},
+				},
+			}
+			patchCalled := false
+			fakeClient = fake.NewClientBuilder().WithObjects(pod).WithInterceptorFuncs(
+				interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch,
+						obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						patchCalled = true
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				}).Build()
+
+			err := AnnotateObject(ctx, pod, "same-key", "same-value", fakeClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(patchCalled).To(BeFalse())
+		})
+	})
+})

--- a/pkg/utils/suite_test.go
+++ b/pkg/utils/suite_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestUtils(t *testing.T) {
+	log.SetLogger(zap.New(
+		zap.WriteTo(GinkgoWriter),
+		zap.Level(zapcore.Level(-2)),
+		zap.UseDevMode(true)))
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Package utils Suite")
+}


### PR DESCRIPTION
## Summary

Backport of [PR #1178](https://github.com/openshift/sriov-network-operator/pull/1178) (OCPBUGS-78148 / release-4.21) to release-4.20.

Fixes OCPBUGS-79399

### Root Cause

After a node reboots (e.g., due to MachineConfig rollout), the sriov-network-config-daemon takes time to configure VFs. During this window, the device plugin can start advertising SR-IOV resources before configuration is complete, causing the node to become `Ready` and the scheduler to place VNF workloads on it — before the VFs are actually usable.

Each VF that fails `VFIsReady()` waits 10s before the `RebindVfToDefaultDriver()` workaround kicks in, making full configuration take 30+ minutes on nodes with many VFs.

### Fix

Add a `BlockDevicePluginUntilConfigured` feature gate. When enabled:
- The device plugin daemonset includes an init container that sets a `wait-for-config` annotation on its pod
- The init container blocks until sriov-config-daemon removes this annotation
- sriov-config-daemon removes the annotation **after** SR-IOV configuration is fully applied
- This prevents pods from being scheduled to the node before VFs are ready

This is a cherry-pick of the upstream commits from release-4.21, adapted for release-4.20's `loadedPlugins` architecture (release-4.21 had already been refactored to use `additionalPlugins`/`mainPlugin`).

## Changes

- `cmd/sriov-network-config-daemon/waitforconfig.go` (new): wait-for-config subcommand used by the init container
- `bindata/manifests/plugins/sriov-device-plugin.yaml`: add init container to device plugin daemonset (when feature gate enabled)
- `pkg/daemon/daemon.go`: block/unblock logic; restart device plugin before config when gate enabled; skip wait when no interfaces configured
- `pkg/featuregate/featuregate.go`: add `BlockDevicePluginUntilConfigured` feature gate
- `config/rbac/`: RBAC for device plugin pod annotation access
- `Makefile`: bump setup-envtest to release-0.20

## Testing

- `go build ./...`: PASS
- `go vet ./...`: PASS
- `./pkg/daemon/...` integration tests: PASS
- `./pkg/featuregate/...` unit tests: PASS
- `./controllers/...` integration tests: PASS
- `./cmd/sriov-network-config-daemon/...` tests: PASS

## Related

- Jira: https://redhat.atlassian.net/browse/OCPBUGS-79399
- Parent bug (4.21): https://redhat.atlassian.net/browse/OCPBUGS-78148
- Original bug: https://redhat.atlassian.net/browse/OCPBUGS-66342
- Upstream PR 1 (k8snetworkplumbingwg): https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/994
- Upstream PR 2 (k8snetworkplumbingwg): https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/1038
- Backport of: https://github.com/openshift/sriov-network-operator/pull/1178