### PR TITLE
OCPBUGS-86028: Enable MellanoxFirmwareResetFeatureGate by default

### DIFF
--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -16,7 +16,7 @@ var DefaultFeatureStates = map[string]bool{
 	consts.MetricsExporterFeatureGate:                  false,
 	consts.ManageSoftwareBridgesFeatureGate:            false,
 	consts.BlockDevicePluginUntilConfiguredFeatureGate: true,
-	consts.MellanoxFirmwareResetFeatureGate:            false,
+	consts.MellanoxFirmwareResetFeatureGate:            true,
 }
 
 // FeatureGate provides methods to check state of the feature

--- a/pkg/featuregate/featuregate_test.go
+++ b/pkg/featuregate/featuregate_test.go
@@ -40,7 +40,7 @@ var _ = Describe("FeatureGate", func() {
 			Expect(f.IsEnabled(consts.MetricsExporterFeatureGate)).To(BeFalse())
 			Expect(f.IsEnabled(consts.ManageSoftwareBridgesFeatureGate)).To(BeFalse())
 			Expect(f.IsEnabled(consts.BlockDevicePluginUntilConfiguredFeatureGate)).To(BeTrue())
-			Expect(f.IsEnabled(consts.MellanoxFirmwareResetFeatureGate)).To(BeFalse())
+			Expect(f.IsEnabled(consts.MellanoxFirmwareResetFeatureGate)).To(BeTrue())
 		})
 		It("should override real default feature state", func() {
 			f := New()

--- a/pkg/plugins/mellanox/mellanox_plugin_test.go
+++ b/pkg/plugins/mellanox/mellanox_plugin_test.go
@@ -339,7 +339,7 @@ var _ = Describe("SRIOV", Ordered, func() {
 		})
 
 		It("should call mlx config fw without fwreset if feature flag is disabled", func() {
-			vars.FeatureGate.Init(nil)
+			vars.FeatureGate.Init(map[string]bool{consts.MellanoxFirmwareResetFeatureGate: false})
 			h.EXPECT().IsKernelLockdownMode().Return(false)
 			h.EXPECT().MlxConfigFW(gomock.Any()).Return(nil)
 			err := m.Apply()


### PR DESCRIPTION
This feature gate is used to enable the Mellanox firmware reset feature.

The reason we enable this feature gate is because on newer mstflint version mstconfig command sends MFRL with bit 6 AND bit 3 ((1<<6)|(1<<3)). some cards like ConnectX-6 Dx firmware does not support the bit 3 (PCIe link toggle) reset trigger for this operation, so the MFRL SET command fails (rc != 0).
The code returns "Please power cycle machine to load new configurations."

The operator does not have access to out of band management system to make a power cycle. so instead we run mstfwreset command to reset the firmware.


(cherry picked from commit 518df93bb238a67bcf65ff49488e0eb79d7053fd)