### PR TITLE
Fix metrics exporter test: replace wget with curl

### DIFF
--- a/test/conformance/tests/test_exporter_metrics.go
+++ b/test/conformance/tests/test_exporter_metrics.go
@@ -190,7 +190,7 @@ func getMetricsForNode(nodeName string) map[string]*dto.MetricFamily {
 
 	metricsExporterPod := metricsExporterPods.Items[0]
 
-	command := []string{"wget", "-qO-", "http://127.0.0.1:9110/metrics"}
+	command := []string{"curl", "-s", "http://127.0.0.1:9110/metrics"}
 	stdout, stderr, err := pod.ExecCommand(clients, &metricsExporterPod, command...)
 	Expect(err).ToNot(HaveOccurred(),
 		"pod: [%s/%s] command: [%v]\nstdout: %s\nstderr: %s", metricsExporterPod.Namespace, metricsExporterPod.Name, command, stdout, stderr)


### PR DESCRIPTION
The metrics exporter container image does not include wget, causing the "collects metrics regarding receiving traffic via VF" test to fail. Use curl instead, which is consistent with the same file's Prometheus query helper.