### PR TITLE
OCPBUGS-86847,OCPBUGS-86853: [release-4.20] Backport Mellanox firmware reset defaults

### DIFF
--- a/Dockerfile.sriov-network-config-daemon.ocp
+++ b/Dockerfile.sriov-network-config-daemon.ocp
@@ -4,7 +4,7 @@ COPY . .
 RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
 
 FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
-RUN yum -y update && ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n mstflint ; fi) && yum -y install pciutils hwdata $ARCH_DEP_PKGS && yum clean all
+RUN yum -y update && ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n mstflint ; fi) && yum -y install pciutils hwdata kmod $ARCH_DEP_PKGS && yum clean all
 LABEL io.k8s.display-name="OpenShift sriov-network-config-daemon" \
       io.k8s.description="This is a daemon that manage and config sriov network devices in Openshift cluster" \
       io.openshift.tags="openshift,networking,sr-iov" \

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -16,7 +16,7 @@ var DefaultFeatureStates = map[string]bool{
 	consts.MetricsExporterFeatureGate:                  false,
 	consts.ManageSoftwareBridgesFeatureGate:            false,
 	consts.BlockDevicePluginUntilConfiguredFeatureGate: true,
-	consts.MellanoxFirmwareResetFeatureGate:            false,
+	consts.MellanoxFirmwareResetFeatureGate:            true,
 }
 
 // FeatureGate provides methods to check state of the feature

--- a/pkg/featuregate/featuregate_test.go
+++ b/pkg/featuregate/featuregate_test.go
@@ -40,7 +40,7 @@ var _ = Describe("FeatureGate", func() {
 			Expect(f.IsEnabled(consts.MetricsExporterFeatureGate)).To(BeFalse())
 			Expect(f.IsEnabled(consts.ManageSoftwareBridgesFeatureGate)).To(BeFalse())
 			Expect(f.IsEnabled(consts.BlockDevicePluginUntilConfiguredFeatureGate)).To(BeTrue())
-			Expect(f.IsEnabled(consts.MellanoxFirmwareResetFeatureGate)).To(BeFalse())
+			Expect(f.IsEnabled(consts.MellanoxFirmwareResetFeatureGate)).To(BeTrue())
 		})
 		It("should override real default feature state", func() {
 			f := New()

--- a/pkg/plugins/mellanox/mellanox_plugin_test.go
+++ b/pkg/plugins/mellanox/mellanox_plugin_test.go
@@ -339,7 +339,7 @@ var _ = Describe("SRIOV", Ordered, func() {
 		})
 
 		It("should call mlx config fw without fwreset if feature flag is disabled", func() {
-			vars.FeatureGate.Init(nil)
+			vars.FeatureGate.Init(map[string]bool{consts.MellanoxFirmwareResetFeatureGate: false})
 			h.EXPECT().IsKernelLockdownMode().Return(false)
 			h.EXPECT().MlxConfigFW(gomock.Any()).Return(nil)
 			err := m.Apply()


### PR DESCRIPTION
## Summary
- install `kmod` in the downstream config daemon image so `mstfwreset` support works with newer `mstflint`
- enable `MellanoxFirmwareResetFeatureGate` by default in the release-4.20 branch
- preserve the release-4.20 base image while backporting the downstream-only Dockerfile change

## Test plan
- [ ] Verify cherry-picks apply cleanly on `release-4.20`
- [ ] Run the relevant unit tests
- [ ] Validate the downstream image still builds successfully

Made with [Cursor](https://cursor.com)