### PR TITLE
OCPBUGS-87999,OCPBUGS-88000: [release-4.19] Backport Mellanox firmware reset defaults

### DIFF
--- a/Dockerfile.sriov-network-config-daemon.ocp
+++ b/Dockerfile.sriov-network-config-daemon.ocp
@@ -4,7 +4,7 @@ COPY . .
 RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
 
 FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
-RUN yum -y update && ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n mstflint ; fi) && yum -y install pciutils hwdata $ARCH_DEP_PKGS && yum clean all
+RUN yum -y update && ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n mstflint ; fi) && yum -y install pciutils hwdata kmod $ARCH_DEP_PKGS && yum clean all
 LABEL io.k8s.display-name="OpenShift sriov-network-config-daemon" \
       io.k8s.description="This is a daemon that manage and config sriov network devices in Openshift cluster" \
       io.openshift.tags="openshift,networking,sr-iov" \

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -2,33 +2,56 @@ package featuregate
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
+
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
 )
 
+// DefaultFeatureStates contains the default states for the feature gates
+var DefaultFeatureStates = map[string]bool{
+	consts.ParallelNicConfigFeatureGate:                false,
+	consts.ResourceInjectorMatchConditionFeatureGate:   false,
+	consts.MetricsExporterFeatureGate:                  false,
+	consts.ManageSoftwareBridgesFeatureGate:            false,
+	consts.BlockDevicePluginUntilConfiguredFeatureGate: true,
+	consts.MellanoxFirmwareResetFeatureGate:            true,
+}
 // FeatureGate provides methods to check state of the feature
 type FeatureGate interface {
 	// IsEnabled returns state of the feature,
 	// if feature name is unknown will always return false
 	IsEnabled(feature string) bool
 	// Init set state for the features from the provided map.
-	// completely removes the previous state
+	// The provided map is merged with the default features state.
 	Init(features map[string]bool)
 	// String returns string representation of the feature state
 	String() string
 }
 
-// New returns default implementation of the FeatureGate interface
+// New returns default implementation of the FeatureGate interface with the default features state
 func New() FeatureGate {
 	return &featureGate{
-		lock:  &sync.RWMutex{},
-		state: map[string]bool{},
+		lock:            &sync.RWMutex{},
+		state:           map[string]bool{},
+		defaultFeatures: DefaultFeatureStates,
+	}
+}
+
+// NewWithDefaultFeatures returns a new FeatureGate with the default features state explicitly set
+func NewWithDefaultFeatures(defaultFeatures map[string]bool) FeatureGate {
+	return &featureGate{
+		lock:            &sync.RWMutex{},
+		state:           map[string]bool{},
+		defaultFeatures: defaultFeatures,
 	}
 }
 
 type featureGate struct {
-	lock  *sync.RWMutex
-	state map[string]bool
+	lock            *sync.RWMutex
+	state           map[string]bool
+	defaultFeatures map[string]bool
 }
 
 // IsEnabled returns state of the feature,
@@ -40,17 +63,19 @@ func (fg *featureGate) IsEnabled(feature string) bool {
 }
 
 // Init set state for the features from the provided map.
-// completely removes the previous state
+// The provided features override the default values.
 func (fg *featureGate) Init(features map[string]bool) {
 	fg.lock.Lock()
 	defer fg.lock.Unlock()
-	fg.state = make(map[string]bool, len(features))
-	for k, v := range features {
-		fg.state[k] = v
+	state := maps.Clone(fg.defaultFeatures)
+	if state == nil {
+		state = map[string]bool{}
 	}
+	maps.Copy(state, features)
+	fg.state = state
 }
 
-// String returns string representation of the feature state
+// String returns string representation of the features state
 func (fg *featureGate) String() string {
 	fg.lock.RLock()
 	defer fg.lock.RUnlock()

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -11,13 +11,13 @@ import (
 
 // DefaultFeatureStates contains the default states for the feature gates
 var DefaultFeatureStates = map[string]bool{
-	consts.ParallelNicConfigFeatureGate:                false,
-	consts.ResourceInjectorMatchConditionFeatureGate:   false,
-	consts.MetricsExporterFeatureGate:                  false,
-	consts.ManageSoftwareBridgesFeatureGate:            false,
-	consts.BlockDevicePluginUntilConfiguredFeatureGate: true,
-	consts.MellanoxFirmwareResetFeatureGate:            true,
+	consts.ParallelNicConfigFeatureGate:              false,
+	consts.ResourceInjectorMatchConditionFeatureGate: false,
+	consts.MetricsExporterFeatureGate:                false,
+	consts.ManageSoftwareBridgesFeatureGate:          false,
+	consts.MellanoxFirmwareResetFeatureGate:          true,
 }
+
 // FeatureGate provides methods to check state of the feature
 type FeatureGate interface {
 	// IsEnabled returns state of the feature,

--- a/pkg/featuregate/featuregate_test.go
+++ b/pkg/featuregate/featuregate_test.go
@@ -39,13 +39,12 @@ var _ = Describe("FeatureGate", func() {
 			Expect(f.IsEnabled(consts.ResourceInjectorMatchConditionFeatureGate)).To(BeFalse())
 			Expect(f.IsEnabled(consts.MetricsExporterFeatureGate)).To(BeFalse())
 			Expect(f.IsEnabled(consts.ManageSoftwareBridgesFeatureGate)).To(BeFalse())
-			Expect(f.IsEnabled(consts.BlockDevicePluginUntilConfiguredFeatureGate)).To(BeTrue())
 			Expect(f.IsEnabled(consts.MellanoxFirmwareResetFeatureGate)).To(BeTrue())
 		})
 		It("should override real default feature state", func() {
 			f := New()
-			f.Init(map[string]bool{consts.BlockDevicePluginUntilConfiguredFeatureGate: false})
-			Expect(f.IsEnabled(consts.BlockDevicePluginUntilConfiguredFeatureGate)).To(BeFalse())
+			f.Init(map[string]bool{consts.MellanoxFirmwareResetFeatureGate: false})
+			Expect(f.IsEnabled(consts.MellanoxFirmwareResetFeatureGate)).To(BeFalse())
 		})
 	})
 	Context("String", func() {

--- a/pkg/featuregate/featuregate_test.go
+++ b/pkg/featuregate/featuregate_test.go
@@ -3,6 +3,8 @@ package featuregate
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
 )
 
 var _ = Describe("FeatureGate", func() {
@@ -17,6 +19,33 @@ var _ = Describe("FeatureGate", func() {
 			f.Init(map[string]bool{"feat1": true, "feat2": false})
 			Expect(f.IsEnabled("feat1")).To(BeTrue())
 			Expect(f.IsEnabled("feat2")).To(BeFalse())
+		})
+		It("should apply default feature state", func() {
+			f := NewWithDefaultFeatures(map[string]bool{"default1": true, "default2": false})
+			f.Init(nil)
+			Expect(f.IsEnabled("default1")).To(BeTrue())
+			Expect(f.IsEnabled("default2")).To(BeFalse())
+		})
+		It("should override default feature state", func() {
+			f := NewWithDefaultFeatures(map[string]bool{"feat1": false, "feat2": true})
+			f.Init(map[string]bool{"feat1": true})
+			Expect(f.IsEnabled("feat1")).To(BeTrue())
+			Expect(f.IsEnabled("feat2")).To(BeTrue())
+		})
+		It("should apply real default feature states", func() {
+			f := New()
+			f.Init(nil)
+			Expect(f.IsEnabled(consts.ParallelNicConfigFeatureGate)).To(BeFalse())
+			Expect(f.IsEnabled(consts.ResourceInjectorMatchConditionFeatureGate)).To(BeFalse())
+			Expect(f.IsEnabled(consts.MetricsExporterFeatureGate)).To(BeFalse())
+			Expect(f.IsEnabled(consts.ManageSoftwareBridgesFeatureGate)).To(BeFalse())
+			Expect(f.IsEnabled(consts.BlockDevicePluginUntilConfiguredFeatureGate)).To(BeTrue())
+			Expect(f.IsEnabled(consts.MellanoxFirmwareResetFeatureGate)).To(BeTrue())
+		})
+		It("should override real default feature state", func() {
+			f := New()
+			f.Init(map[string]bool{consts.BlockDevicePluginUntilConfiguredFeatureGate: false})
+			Expect(f.IsEnabled(consts.BlockDevicePluginUntilConfiguredFeatureGate)).To(BeFalse())
 		})
 	})
 	Context("String", func() {

--- a/pkg/plugins/mellanox/mellanox_plugin_test.go
+++ b/pkg/plugins/mellanox/mellanox_plugin_test.go
@@ -339,7 +339,7 @@ var _ = Describe("SRIOV", Ordered, func() {
 		})
 
 		It("should call mlx config fw without fwreset if feature flag is disabled", func() {
-			vars.FeatureGate.Init(nil)
+			vars.FeatureGate.Init(map[string]bool{consts.MellanoxFirmwareResetFeatureGate: false})
 			h.EXPECT().IsKernelLockdownMode().Return(false)
 			h.EXPECT().MlxConfigFW(gomock.Any()).Return(nil)
 			err := m.Apply()


### PR DESCRIPTION
## Summary
- install `kmod` in the downstream config daemon image so `mstfwreset` support works with newer `mstflint`
- enable `MellanoxFirmwareResetFeatureGate` by default on `release-4.19`
- adapt the older `release-4.19` feature-gate implementation so the new default behavior works with the APIs available on that branch
