### PR TITLE
test: wrap vfio-pci runCommandOnConfigDaemon calls in Eventually (CNF-24222)

### DIFF
--- a/test/conformance/tests/test_policy_configuration.go
+++ b/test/conformance/tests/test_policy_configuration.go
@@ -86,8 +86,12 @@ var _ = Describe("[sriov] operator", Ordered, func() {
 					}, 10*time.Minute, time.Second).Should(Equal(int64(5)))
 
 					By("validate the pf info exist on host")
-					output, _, err := runCommandOnConfigDaemon(vfioNode, "/bin/bash", "-c", "ls /host/etc/sriov-operator/pci/ | wc -l")
-					Expect(err).ToNot(HaveOccurred())
+					var output string
+					Eventually(func(g Gomega) {
+						var execErr error
+						output, _, execErr = runCommandOnConfigDaemon(vfioNode, "/bin/bash", "-c", "ls /host/etc/sriov-operator/pci/ | wc -l")
+						g.Expect(execErr).ToNot(HaveOccurred())
+					}, 2*time.Minute, 5*time.Second).Should(Succeed())
 					Expect(output).ToNot(Equal("1"))
 
 					By("Creating sriov network to use the vfio device")
@@ -131,8 +135,11 @@ var _ = Describe("[sriov] operator", Ordered, func() {
 					}, 2*time.Minute, time.Second).Should(Equal(int64(0)))
 
 					By("validate the pf info doesn't exist on the host anymore")
-					output, _, err = runCommandOnConfigDaemon(vfioNode, "/bin/bash", "-c", "ls /host/etc/sriov-operator/pci/ | wc -l")
-					Expect(err).ToNot(HaveOccurred())
+					Eventually(func(g Gomega) {
+						var execErr error
+						output, _, execErr = runCommandOnConfigDaemon(vfioNode, "/bin/bash", "-c", "ls /host/etc/sriov-operator/pci/ | wc -l")
+						g.Expect(execErr).ToNot(HaveOccurred())
+					}, 2*time.Minute, 5*time.Second).Should(Succeed())
 					Expect(output).ToNot(Equal("0"))
 				})
 			})


### PR DESCRIPTION
## Problem

In the vfio-pci node policy test, after creating a `SriovNetworkNodePolicy` with `vfio-pci` driver, the single worker node reboots/reconfigures its hardware. The test then calls `runCommandOnConfigDaemon` to validate PF info on the host, but because the node just rebooted, the API server to kubelet/pod connection has not fully recovered, resulting in:

```
error dialing backend: EOF (HTTP 500)
```

This is a race condition (same pattern as [CNF-24178](https://redhat.atlassian.net/browse/CNF-24178)) where the test attempts to exec into the config daemon pod before the apiserver-to-kubelet connections are re-established after the SRIOV-induced node disruption.

## Fix

Wrap both `runCommandOnConfigDaemon` calls in the vfio-pci test in `Eventually` blocks with a 2-minute timeout and 5-second retry interval. This allows the test to retry on transient `error dialing backend: EOF` errors rather than failing immediately.

The pattern matches the existing fix in `test_sriov_operator.go:1530-1538` which already uses this approach for similar post-reboot checks.

## Related

- [CNF-24222](https://redhat.atlassian.net/browse/CNF-24222)
- [CNF-24178](https://redhat.atlassian.net/browse/CNF-24178) (similar race condition fix)