### PR TITLE
rbac: grant operator access to config.openshift.io apiservers

### DIFF
--- a/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
@@ -343,6 +343,7 @@ spec:
         - apiGroups:
           - config.openshift.io
           resources:
+          - apiservers
           - infrastructures
           verbs:
           - get

--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -34,7 +34,7 @@ rules:
   resources: ["*"]
   verbs: ["*"]
 - apiGroups: ["config.openshift.io"]
-  resources: ["infrastructures"]
+  resources: ["infrastructures", "apiservers"]
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deployment/sriov-network-operator-chart/templates/clusterrole.yaml
+++ b/deployment/sriov-network-operator-chart/templates/clusterrole.yaml
@@ -36,7 +36,7 @@ rules:
     resources: ["*"]
     verbs: ["*"]
   - apiGroups: ["config.openshift.io"]
-    resources: ["infrastructures"]
+    resources: ["infrastructures", "apiservers"]
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
+++ b/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
@@ -343,6 +343,7 @@ spec:
         - apiGroups:
           - config.openshift.io
           resources:
+          - apiservers
           - infrastructures
           verbs:
           - get


### PR DESCRIPTION
## Summary
- Add `apiservers` to the `config.openshift.io` RBAC rules for the `sriov-network-operator` ServiceAccount
- Updates CSV files (`manifests/stable/` and `bundle/manifests/`), `deploy/clusterrole.yaml`, and the Helm chart template

## Why
PR #1230 (upstream merge) introduces a `Watches(&configv1.APIServer{})` in `SriovOperatorConfigReconciler` for TLS cipher/version control. Without the corresponding RBAC permission, the operator crashes on startup (`CrashLoopBackOff`) because the APIServer informer is denied by RBAC when installed via OLM.

This PR lands the RBAC fix separately so #1230 can rebase on top of it.

## Test plan
- [ ] CI `operator-e2e` job passes (operator pod starts without CrashLoopBackOff)
- [ ] Verify no regressions in existing validation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)