### PR TITLE
OCPBUGS-98152: [release-4.18] Handle missing sriov_numvfs during Mellanox firmware reset

### DIFF
--- a/pkg/host/internal/sriov/sriov.go
+++ b/pkg/host/internal/sriov/sriov.go
@@ -74,6 +74,15 @@ func New(utilsHelper utils.CmdInterface,
 func (s *sriov) SetSriovNumVfs(pciAddr string, numVfs int) error {
 	log.Log.V(2).Info("SetSriovNumVfs(): set NumVfs", "device", pciAddr, "numVfs", numVfs)
 	numVfsFilePath := filepath.Join(vars.FilesystemRoot, consts.SysBusPciDevices, pciAddr, consts.NumVfsFile)
+
+	// In case we want to reset the VFs number to 0 but the sriov_numvfs file does not exist, we just return without error
+	if numVfs == 0 {
+		if _, err := os.Stat(numVfsFilePath); os.IsNotExist(err) {
+			log.Log.V(2).Info("SetSriovNumVfs(): NumVfs file does not exist, nothing to reset", "path", numVfsFilePath)
+			return nil
+		}
+	}
+
 	bs := []byte(strconv.Itoa(numVfs))
 	err := os.WriteFile(numVfsFilePath, []byte("0"), os.ModeAppend)
 	if err != nil {

--- a/pkg/host/internal/sriov/sriov_test.go
+++ b/pkg/host/internal/sriov/sriov_test.go
@@ -155,6 +155,12 @@ var _ = Describe("SRIOV", func() {
 			Expect(s.SetSriovNumVfs("0000:d8:00.0", 5)).NotTo(HaveOccurred())
 			helpers.GinkgoAssertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs", strconv.Itoa(5))
 		})
+		It("set to 0 - succeed when numvfs file does not exist", func() {
+			helpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
+				Dirs: []string{"/sys/bus/pci/devices/0000:d8:00.0"},
+			})
+			Expect(s.SetSriovNumVfs("0000:d8:00.0", 0)).NotTo(HaveOccurred())
+		})
 		It("fail - no such device", func() {
 			Expect(s.SetSriovNumVfs("0000:d8:00.0", 5)).To(HaveOccurred())
 		})


### PR DESCRIPTION
## Summary
- skip resetting `sriov_numvfs` to `0` when the sysfs file is not present after staging Mellanox firmware changes
- avoid failing the Mellanox firmware reset flow while `SRIOV_EN` is still disabled until reboot

## Test plan
- Not run (backport only)

Made with [Cursor](https://cursor.com)