### PR TITLE
Remove leftover debug object dumps

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -79,7 +79,6 @@ func InitNicIDMapFromConfigMap(client kubernetes.Interface, namespace string) er
 	for _, v := range cm.Data {
 		NicIDMap = append(NicIDMap, v)
 	}
-	fmt.Printf("NicIDMap: %+v\n", NicIDMap)
 	return nil
 }
 

--- a/test/util/cluster/cluster.go
+++ b/test/util/cluster/cluster.go
@@ -64,7 +64,6 @@ func DiscoverSriov(clients *testclient.ClientSet, operatorNamespace string) (*En
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve note states %v", err)
 	}
-	fmt.Printf("nodeStates: %+v\n", nodeStates)
 
 	res := &EnabledNodes{}
 	res.States = make(map[string]sriovv1.SriovNetworkNodeState)
@@ -446,7 +445,6 @@ func DiscoverSriovForAws(clients *testclient.ClientSet, operatorNamespace string
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover sriov nodes: %w", err)
 	}
-	fmt.Printf("tmpEnabledNodes: %+v\n", tmpEnabledNodes)
 
 	res := &EnabledNodes{}
 	res.States = make(map[string]sriovv1.SriovNetworkNodeState)

--- a/test/util/nodes/nodes.go
+++ b/test/util/nodes/nodes.go
@@ -24,7 +24,6 @@ func init() {
 // The NODES_SELECTOR must be in the form of label=value.
 // For example: NODES_SELECTOR="sctp=true"
 func MatchingOptionalSelectorState(clients *client.ClientSet, toFilter []sriovv1.SriovNetworkNodeState) ([]sriovv1.SriovNetworkNodeState, error) {
-	fmt.Printf("MatchingOptionalSelectorState: %+v\n", toFilter)
 	if NodesSelector == "" {
 		return toFilter, nil
 	}


### PR DESCRIPTION
Three fmt.Printf calls dumped whole API objects on every discovery pass and account for the bulk of a conformance run's log volume:

- test/util/cluster/cluster.go and test/util/nodes/nodes.go print the full SriovNetworkNodeState list, managedFields included, once per test.
- api/v1/helper.go prints the entire supported-NIC table. That one is not test code: InitNicIDMapFromConfigMap is called by the operator, the webhook and the config daemon, so each of them wrote the table to stdout with fmt.Printf instead of using the logr instance this file already holds.

The two remaining Printf calls in DiscoverSriovForAws are left alone: they print a small map and a single line per NIC, and they only run on AWS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed diagnostic output from configuration loading and cluster and node discovery operations.
  * No functional behavior or public interfaces changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->