### PR TITLE
OCPBUGS-95059: Merge https://github.com/k8snetworkplumbingwg/sriov-network-operator:master into main

### DIFF
--- a/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sriov-network-operator.clusterserviceversion.yaml
@@ -100,7 +100,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-sriov-network-operator:5.0
-    createdAt: "2026-08-16T23:49:04Z"
+    createdAt: "2026-09-02T23:49:22Z"
     description: An operator for configuring SR-IOV components and initializing SRIOV
       network devices in Openshift cluster.
     features.operators.openshift.io/cnf: "false"

--- a/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
+++ b/manifests/stable/sriov-network-operator.clusterserviceversion.yaml
@@ -100,7 +100,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-sriov-network-operator:5.0
-    createdAt: "2026-08-16T23:49:04Z"
+    createdAt: "2026-09-02T23:49:22Z"
     description: An operator for configuring SR-IOV components and initializing SRIOV
       network devices in Openshift cluster.
     features.operators.openshift.io/cnf: "false"

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -240,6 +240,16 @@ func (dn *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 
+	// updateSyncState copies live ObjectMeta onto desiredNodeState. If a newer spec
+	// arrived during this reconcile, Generation no longer matches the Spec we hold.
+	// Requeue so the next loop fetches the latest spec instead of applying a stale one.
+	if desiredNodeState.GetGeneration() != latest {
+		reqLogger.Info("nodeState generation changed during reconcile, requeue",
+			"reconcile-generation", latest,
+			"latest-generation", desiredNodeState.GetGeneration())
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
 	reqReboot, reqDrain, err := dn.checkOnNodeStateChange(desiredNodeState)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -282,7 +292,7 @@ func (dn *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	// if we finish the drain we should run apply here
 	if dn.isDrainCompleted(reqDrain, desiredNodeState) {
-		return dn.apply(ctx, desiredNodeState, reqReboot, sriovResult)
+		return dn.apply(ctx, desiredNodeState, reqReboot, sriovResult, latest)
 	}
 
 	return ctrl.Result{}, nil
@@ -368,10 +378,12 @@ func (dn *NodeReconciler) CheckSystemdStatus() (*hosttypes.SriovResult, bool, er
 // 4. Restarting the device plugin pod on the node.
 // 5. Requesting annotation updates for draining the idle state of the node.
 // 6. Synchronizing with the host network status and updating the sync status of the node in the nodeState object.
-// 7. Updating the lastAppliedGeneration to the current generation.
-func (dn *NodeReconciler) apply(ctx context.Context, desiredNodeState *sriovnetworkv1.SriovNetworkNodeState, reqReboot bool, sriovResult *hosttypes.SriovResult) (ctrl.Result, error) {
+// 7. Updating lastAppliedGeneration to appliedGeneration, which must be the generation
+// fetched at the start of this reconcile. updateSyncState copies live ObjectMeta onto
+// desiredNodeState, so reading Generation after a status update can observe a newer
+// spec that has not been applied yet.
+func (dn *NodeReconciler) apply(ctx context.Context, desiredNodeState *sriovnetworkv1.SriovNetworkNodeState, reqReboot bool, sriovResult *hosttypes.SriovResult, appliedGeneration int64) (ctrl.Result, error) {
 	reqLogger := log.FromContext(ctx).WithName("Apply")
-	appliedGeneration := desiredNodeState.Generation
 
 	// Restart the device plugin *before* applying configuration if the
 	// BlockDevicePluginUntilConfiguredFeatureGate feature is enabled.

--- a/pkg/plugins/generic/generic_plugin.go
+++ b/pkg/plugins/generic/generic_plugin.go
@@ -186,6 +186,13 @@ func (p *GenericPlugin) CheckStatusChanges(current *sriovnetworkv1.SriovNetworkN
 		}
 	}
 
+	if rdmaModeNeedsUpdate(current) {
+		log.Log.Info("CheckStatusChanges(): rdma mode needs to be updated",
+			"desired", current.Spec.System.RdmaMode,
+			"current", current.Status.System.RdmaMode)
+		return true, nil
+	}
+
 	shouldUpdate, err := p.shouldUpdateKernelArgs()
 	if err != nil {
 		log.Log.Error(err, "generic-plugin CheckStatusChanges(): failed to verify missing kernel arguments")
@@ -193,6 +200,16 @@ func (p *GenericPlugin) CheckStatusChanges(current *sriovnetworkv1.SriovNetworkN
 	}
 
 	return shouldUpdate, nil
+}
+
+// rdmaModeNeedsUpdate reports whether the nodeState spec requests an RDMA mode
+// that differs from the mode currently reported in status. An empty spec mode
+// means the operator is not managing RDMA, so no update is required.
+func rdmaModeNeedsUpdate(state *sriovnetworkv1.SriovNetworkNodeState) bool {
+	if state.Spec.System.RdmaMode == "" {
+		return false
+	}
+	return state.Spec.System.RdmaMode != state.Status.System.RdmaMode
 }
 
 func (p *GenericPlugin) syncDriverState() error {

--- a/pkg/plugins/generic/generic_plugin_test.go
+++ b/pkg/plugins/generic/generic_plugin_test.go
@@ -934,6 +934,24 @@ var _ = Describe("Generic plugin", func() {
 				Expect(genericPlugin.(*GenericPlugin).DesiredKernelArgs[consts.KernelArgIommuPt]).To(BeTrue())
 			})
 
+			It("should detect rdma mode drift from spec vs status without prior kernel-arg sync", func() {
+				state := rdmaState.DeepCopy()
+				state.Spec.System.RdmaMode = consts.RdmaSubsystemModeExclusive
+				state.Status.System.RdmaMode = consts.RdmaSubsystemModeShared
+
+				changed, err := genericPlugin.CheckStatusChanges(state)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(changed).To(BeTrue())
+			})
+			It("should not detect rdma drift when spec matches status", func() {
+				state := rdmaState.DeepCopy()
+				state.Spec.System.RdmaMode = consts.RdmaSubsystemModeExclusive
+				state.Status.System.RdmaMode = consts.RdmaSubsystemModeExclusive
+
+				changed, err := genericPlugin.CheckStatusChanges(state)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(changed).To(BeFalse())
+			})
 			It("should enable rdma shared mode", func() {
 				hostHelper.EXPECT().SetRDMASubsystem(consts.RdmaSubsystemModeShared).Return(nil)
 				err := genericPlugin.(*GenericPlugin).configRdmaKernelArg(rdmaState)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented stale network node configurations from being applied when configuration changes occur during reconciliation.
  - Improved detection of RDMA mode changes so node networking updates are triggered when configured and reported modes differ.
  - Avoided unnecessary updates when the RDMA mode already matches.

- **Chores**
  - Updated release metadata timestamps for the latest operator artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->